### PR TITLE
small update to 404 example message

### DIFF
--- a/components/examples/404.json
+++ b/components/examples/404.json
@@ -1,3 +1,3 @@
 {
-    "msg": "Not Found - The specified resource could not be found."
+    "msg": "Specified Resource Not Found"
 }

--- a/components/schemas/404-error.yaml
+++ b/components/schemas/404-error.yaml
@@ -2,4 +2,4 @@ type: object
 properties:
   msg:
     type: string
-    example: Not Found - The specified resource could not be found.
+    example: Specified Resource Not Found


### PR DESCRIPTION
HPE requested the generic example 404 message we display be a little closer to the real message. Made slight change to our 404 example message to make the closest approximation to the variety of potential messages.