### PR TITLE
Update fields of ZoneVcenterConfig

### DIFF
--- a/components/schemas/zoneVcenterConfig.yaml
+++ b/components/schemas/zoneVcenterConfig.yaml
@@ -17,21 +17,16 @@ properties:
     type: string
   rpcMode: 
     type: string
-  _hideHostSelection: 
-    type: string
   hideHostSelection: 
-    type: string
-  _importExisting: 
     type: string
   importExisting: 
     type: string
-  _enableVnc: 
-    type: string
   enableVnc: 
     type: string
-  _enableDiskTypeSelection: 
+  enableDiskTypeSelection: 
     type: string
-  _enableNetworkTypeSelection: 
+    nullable: true
+  enableNetworkTypeSelection: 
     type: string
   diskStorageType: 
     type: string
@@ -84,9 +79,6 @@ properties:
     type: string
     nullable: true
   serviceRegistryId: 
-    type: string
-    nullable: true
-  enableDiskTypeSelection: 
     type: string
     nullable: true
   kubeUrl: 

--- a/components/schemas/zoneVcenterConfig.yaml
+++ b/components/schemas/zoneVcenterConfig.yaml
@@ -1,100 +1,104 @@
 type: object
-properties: 
-  apiUrl: 
+properties:
+  apiUrl:
     type: string
-  username: 
+  username:
     type: string
-  password: 
-    type: string
-    nullable: true
-  datacenter: 
-    type: string
-  cluster: 
-    type: string
-  resourcePoolId: 
-    type: string
-  resourcePool: 
-    type: string
-  rpcMode: 
-    type: string
-  hideHostSelection: 
-    type: string
-  importExisting: 
-    type: string
-  enableVnc: 
-    type: string
-  enableDiskTypeSelection: 
+  password:
     type: string
     nullable: true
-  enableNetworkTypeSelection: 
-    type: string
-  diskStorageType: 
+  apiVersion:
     type: string
     nullable: true
-  applianceUrl: 
+  datacenter:
+    type: string
+  cluster:
+    type: string
+  resourcePoolId:
+    type: string
+  resourcePool:
+    type: string
+  rpcMode:
+    type: string
+  importExisting:
+    type: string
+  enableVnc:
+    type: string
+  enableDiskTypeSelection:
     type: string
     nullable: true
-  datacenterName: 
+  enableStorageTypeSelection:
+    type: string
+  enableNetworkTypeSelection:
+    type: string
+  diskStorageType:
     type: string
     nullable: true
-  networkServer.id: 
+  applianceUrl:
+    type: string
+    nullable: true
+  datacenterName:
+    type: string
+    nullable: true
+  networkServer.id:
     type: string
       # oneOf:
       # - type: string
       # - type: integer
       #   format: int64
-  networkServer: 
+  networkServer:
     type: object
-    properties: 
+    properties:
       id:
         type: string
         # oneOf:
         # - type: string
         # - type: integer
         #   format: int64
-  securityMode: 
-    type: string
-  certificateProvider: 
+  securityServer:
     type: string
     nullable: true
-  backupMode: 
+  securityMode:
+    type: string
+  certificateProvider:
     type: string
     nullable: true
-  replicationMode: 
+  backupMode:
     type: string
     nullable: true
-  dnsIntegrationId: 
+  replicationMode:
     type: string
     nullable: true
-  configCmdbId: 
+  serviceRegistryId:
     type: string
     nullable: true
-  configManagementId: 
-    type: string
-    nullable: true
-  configCmId: 
-    type: string
-    nullable: true
-  securityServer: 
-    type: string
-    nullable: true
-  serviceRegistryId: 
-    type: string
-    nullable: true
-  kubeUrl: 
-    type: string
-    nullable: true
-  apiVersion: 
-    type: string
-    nullable: true
-  datacenterId: 
-    type: string
-    nullable: true
-  configCmdbDiscovery: 
+  configCmdbDiscovery:
     type: boolean
-  distributedWorkerId: 
+  datacenterId:
     type: string
     nullable: true
-  passwordHash: 
+  clusterRef:
+    type: string
+  kubeUrl:
+    type: string
+    nullable: true
+  distributedWorkerId:
+    type: string
+    nullable: true
+  configManagementId:
+    type: string
+    nullable: true
+  configCmdbId:
+    type: string
+    nullable: true
+  configCmId:
+    type: string
+    nullable: true
+  passwordHash:
+    type: string
+    nullable: true
+  hideHostSelection:
+    type: string
+  dnsIntegrationId:
     type: string
     nullable: true


### PR DESCRIPTION
This makes some changes to ZoneVcenterConfig which aims to bring it up to date with more recent versions of responses from the VCenter API.

1. Remove duplicate underscored fields which were causing issues with client generation. I'm guessing these duplicate underscore fields were put in as a temporary measure.

2. Align the other fields with a `config` response from version 7.0 of the VCenter API in an attempt to give a more accurate representation of a `config` response from the VCenter API. I'm aware that the API seems to be on version 8.0 now, so if there are things that are missing or incorrect, then please suggest corrections to my proposed changes.

The updates in point 2 were made considering a response from a VCenter cloud on the Morpheus feature environment, example below with values redacted:

```
{
  "apiUrl": [redacted]
  "username": [redacted]
  "password": [redacted]
  "apiVersion": [redacted]
  "datacenter": [redacted]
  "cluster": [redacted]
  "resourcePoolId": [redacted]
  "resourcePool": [redacted]
  "rpcMode": [redacted]
  "importExisting": [redacted]
  "enableVnc": [redacted]
  "enableDiskTypeSelection": [redacted]
  "enableStorageTypeSelection": [redacted]
  "enableNetworkTypeSelection": [redacted]
  "diskStorageType": [redacted]
  "applianceUrl": [redacted]
  "datacenterName": [redacted]
  "networkServer.id": [redacted]
  "networkServer": [redacted]
    "id": [redacted]
  },
  "securityServer": [redacted]
  "certificateProvider": [redacted]
  "backupMode": [redacted]
  "replicationMode": [redacted]
  "serviceRegistryId": [redacted]
  "configCmdbDiscovery": [redacted]
  "datacenterId": [redacted]
  "clusterRef": [redacted]
  "kubeUrl": [redacted]
  "distributedWorkerId": [redacted]
  "configManagementId": [redacted]
  "configCmdbId": [redacted]
  "configCmId": [redacted]
  "passwordHash": [redacted]
}
```