### PR TITLE
Fix polymorphic default values in schema

### DIFF
--- a/components/schemas/blueprintARMCreate.yaml
+++ b/components/schemas/blueprintARMCreate.yaml
@@ -70,12 +70,12 @@ properties:
       installAgent: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: Install Morpheus Agent
-        default: false
       cloudInitEnabled: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: Cloud Init Enabled
-        default: false

--- a/components/schemas/blueprintARMCreateSuccess.yaml
+++ b/components/schemas/blueprintARMCreateSuccess.yaml
@@ -60,15 +60,15 @@ properties:
       installAgent: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: Install Morpheus Agent
-        default: false
       cloudInitEnabled: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: Cloud Init Enabled
-        default: false
   visibility:
     type: string
     description: Private or Public Access

--- a/components/schemas/blueprintCFTCreateSuccess.yaml
+++ b/components/schemas/blueprintCFTCreateSuccess.yaml
@@ -54,33 +54,33 @@ properties:
       IAM: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: CloudFormation Attribute CAPABILITY_IAM
-        default: false
       CAPABILITY_NAMED_IAM: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: CloudFormation Attribute CAPABILITY_NAMED_IAM
-        default: false
       CAPABILITY_AUTO_EXPAND: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: CloudFormation Attribute CAPABILITY_AUTO_EXPAND
-        default: false
       installAgent: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: Install Morpheus Agent
-        default: false
       cloudInitEnabled: 
         oneOf:
           - type: boolean
+            default: false
           - type: string
         description: Cloud Init Enabled
-        default: false
   visibility:
     type: string
     description: Private or Public Access

--- a/paths/api@cypher@id.yaml
+++ b/paths/api@cypher@id.yaml
@@ -83,9 +83,9 @@ post:
                 - type: string
                 - type: integer
                   format: int64
+                  default: 0
               description: |
                 Time to Live. The lease duration in seconds, or a human readable format eg. 15m, 8h, 7d. The default is 0 meaning Never expires. This only is applied if the cypher does not yet exist and is created.
-              default: 0
             value:
               type: string
               description: The secret value to be stored. This is only parsed if type is passed as `string`.


### PR DESCRIPTION
This PR addresses a number of fields in the schema which incorrectly use default values with the OpenAPI `oneOf` keyword.

This was causing automated tooling which consumes the spec to break. Particularly, with OpenAPI Generator, the models affected were generating with incorrect typing.

Polymorphic schemas themselves can't have `default` values, so the `default` value has been moved to the scope of the intended fields. This keeps the intent of originally including the default value in the spec while fixing compatibility with tools that consume the OpenAPI spec, e.g. client generation tools.