### PR TITLE
Bump OpenAPI version to 3.1.1

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: Morpheus API
   description: |-


### PR DESCRIPTION
This PR is one of a series that aims to get the spec compatible with tooling that consumes it, such as OpenAPI generator to generate clients from the spec.

Bumps the OpenAPI version of the spec to the most recent one.
This indicates the spec is compliant with the most recent version of OpenAPI.

We get some fixes for free with this change when using OpenAPI Generator. Labelling the spec as version 3.0.x seems to cause issues with generating model fields from nullable string enums, so with this change the tooling is able to correctly parse existing nullable string enum schemas.