### PR TITLE
Fix policyCreate nullable string enum

### DIFF
--- a/components/schemas/policyCreate.yaml
+++ b/components/schemas/policyCreate.yaml
@@ -420,14 +420,12 @@ properties:
     type: string
     description: Scope object type.  If none specified, will default to Global (null)
     enum:
-    - null
     - ComputeSite
     - ComputeZone
     - User
     - Role
     - Network
     - Plan
-    default: null
     nullable: true
   refId:
     type: integer


### PR DESCRIPTION
This PR is one of a series that aims to get the spec compatible with tooling that consumes it, such as OpenAPI generator to generate clients from the spec.

The existing syntax used for the nullable string enum found in `policyCreate.yaml` seems to be incompatible with the [swagger-parser](https://github.com/swagger-api/swagger-parser) backend that OpenAPI generator uses. This changes it to a format that the tool can parse.

From looking into this, it seems like what has been valid OpenAPI nullable enum syntax has changed a few times. It seems like there's a couple of different valid ways to express this now. With this PR I'm changing it to a format found in other areas of the Morpheus spec that `swagger-parser` seems to be able to handle. If we need to change it to "canonical" OpenAPI 3.1 syntax, then this can be done in a later PR.