### PR TITLE
Remove multiple tags from endpoints

### DIFF
--- a/paths/api@apps@id@wiki.yaml
+++ b/paths/api@apps@id@wiki.yaml
@@ -4,7 +4,6 @@ get:
     This endpoint retrieves an app Wiki page.
   operationId: getWikiApp
   tags:
-    - Wiki
     - Apps
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -35,7 +34,6 @@ put:
     Updates an app Wiki page.
   operationId: updateWikiApp
   tags:
-    - Wiki
     - Apps
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -48,16 +46,15 @@ put:
             page:
               type: object
               properties:
-                name: 
+                name:
                   type: string
                   example: Sample Doc
                 category:
                   type: string
                   example: info
-                content: 
+                content:
                   type: string
-                  example: #Sample Doc
-                    A sample document in **markdown**.`
+                  example: A sample document in **markdown**.` #Sample Doc
   responses:
     '200':
       description: Successful Request
@@ -65,11 +62,11 @@ put:
         application/json:
           schema:
             allOf:
-            - type: object
-              properties:
-                page:
-                  $ref: ../components/schemas/wikiPage.yaml
-            - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  page:
+                    $ref: ../components/schemas/wikiPage.yaml
+              - $ref: ../components/schemas/200-success.yaml
           examples:
             Wiki Response:
               value:

--- a/paths/api@clusters@id@datastores.yaml
+++ b/paths/api@clusters@id@datastores.yaml
@@ -42,7 +42,6 @@ post:
   operationId: saveClusterDatastore
   tags:
     - Clusters
-    - Datastores
   parameters:
     - $ref: ../components/parameters/clusterId-path.yaml
   requestBody:

--- a/paths/api@clusters@id@datastores@id.yaml
+++ b/paths/api@clusters@id@datastores@id.yaml
@@ -4,7 +4,6 @@ get:
   operationId: getClusterDatastore
   tags: 
     -  Clusters
-    -  Datastores
   parameters:
     - $ref: ../components/parameters/clusterId-path.yaml
     - $ref: ../components/parameters/id-path.yaml
@@ -32,7 +31,6 @@ put:
   operationId: updateClusterDatastore
   tags: 
     -  Clusters
-    -  Datastores
   parameters:
     - $ref: ../components/parameters/clusterId-path.yaml
     - $ref: ../components/parameters/id-path.yaml
@@ -77,7 +75,6 @@ delete:
   operationId: deleteClusterDatastore
   tags:
     - Clusters
-    -  Datastores
   parameters:
     - $ref: ../components/parameters/clusterId-path.yaml
     - $ref: ../components/parameters/id-path.yaml

--- a/paths/api@clusters@id@wiki.yaml
+++ b/paths/api@clusters@id@wiki.yaml
@@ -4,7 +4,6 @@ get:
     This endpoint retrieves a cluster Wiki page.
   operationId: getWikiCluster
   tags:
-    - Wiki
     - Clusters
   parameters:
     - $ref: ../components/parameters/clusterId-path.yaml
@@ -35,7 +34,6 @@ put:
     Updates a cluster Wiki page.
   operationId: updateWikiCluster
   tags:
-    - Wiki
     - Clusters
   parameters:
     - $ref: ../components/parameters/clusterId-path.yaml
@@ -48,16 +46,15 @@ put:
             page:
               type: object
               properties:
-                name: 
+                name:
                   type: string
                   example: Sample Doc
-                category: 
+                category:
                   type: string
                   example: info
-                content: 
+                content:
                   type: string
-                  example: #Sample Doc
-                    A sample document in **markdown**.`
+                  example: A sample document in **markdown**.` #Sample Doc
   responses:
     '200':
       description: Successful Request
@@ -65,11 +62,11 @@ put:
         application/json:
           schema:
             allOf:
-            - type: object
-              properties:
-                page:
-                  $ref: ../components/schemas/wikiPage.yaml
-            - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  page:
+                    $ref: ../components/schemas/wikiPage.yaml
+              - $ref: ../components/schemas/200-success.yaml
           examples:
             Wiki Response:
               value:

--- a/paths/api@groups@id@wiki.yaml
+++ b/paths/api@groups@id@wiki.yaml
@@ -4,7 +4,6 @@ get:
     This endpoint retrieves a group Wiki page.
   operationId: getWikiGroup
   tags:
-    - Wiki
     - Groups
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -35,7 +34,6 @@ put:
     Updates a group Wiki page.
   operationId: updateWikiGroup
   tags:
-    - Wiki
     - Groups
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -48,16 +46,15 @@ put:
             page:
               type: object
               properties:
-                name: 
+                name:
                   type: string
                   example: Sample Doc
-                category: 
+                category:
                   type: string
                   example: info
-                content: 
+                content:
                   type: string
-                  example: #Sample Doc
-                    A sample document in **markdown**.`
+                  example: A sample document in **markdown**.` #Sample Doc
   responses:
     '200':
       description: Successful Request
@@ -65,11 +62,11 @@ put:
         application/json:
           schema:
             allOf:
-            - type: object
-              properties:
-                page:
-                  $ref: ../components/schemas/wikiPage.yaml
-            - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  page:
+                    $ref: ../components/schemas/wikiPage.yaml
+              - $ref: ../components/schemas/200-success.yaml
           examples:
             Wiki Response:
               value:

--- a/paths/api@instances@id@wiki.yaml
+++ b/paths/api@instances@id@wiki.yaml
@@ -4,7 +4,6 @@ get:
     This endpoint retrieves an instance Wiki page.
   operationId: getWikiInstance
   tags:
-    - Wiki
     - Instances
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -35,7 +34,6 @@ put:
     Updates an instance Wiki page.
   operationId: updateWikiInstance
   tags:
-    - Wiki
     - Instances
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -48,16 +46,15 @@ put:
             page:
               type: object
               properties:
-                name: 
+                name:
                   type: string
                   example: Sample Doc
-                category: 
+                category:
                   type: string
                   example: info
-                content: 
+                content:
                   type: string
-                  example: #Sample Doc
-                    A sample document in **markdown**.`
+                  example: A sample document in **markdown**.` #Sample Doc
   responses:
     '200':
       description: Successful Request
@@ -65,11 +62,11 @@ put:
         application/json:
           schema:
             allOf:
-            - type: object
-              properties:
-                page:
-                  $ref: ../components/schemas/wikiPage.yaml
-            - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  page:
+                    $ref: ../components/schemas/wikiPage.yaml
+              - $ref: ../components/schemas/200-success.yaml
           examples:
             Wiki Response:
               value:

--- a/paths/api@ping.yaml
+++ b/paths/api@ping.yaml
@@ -7,7 +7,6 @@ get:
   operationId: ping
   tags:
     - Ping
-    - Health
   responses:
     '200':
       description: Successful Request

--- a/paths/api@servers@id@wiki.yaml
+++ b/paths/api@servers@id@wiki.yaml
@@ -4,7 +4,6 @@ get:
     This endpoint retrieves a server Wiki page.
   operationId: getWikiServer
   tags:
-    - Wiki
     - Hosts
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -35,7 +34,6 @@ put:
     Updates a server Wiki page.
   operationId: updateWikiServer
   tags:
-    - Wiki
     - Hosts
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -48,16 +46,15 @@ put:
             page:
               type: object
               properties:
-                name: 
+                name:
                   type: string
                   example: Sample Doc
-                category: 
+                category:
                   type: string
                   example: info
-                content: 
+                content:
                   type: string
-                  example: #Sample Doc
-                    A sample document in **markdown**.`
+                  example: A sample document in **markdown**.` #Sample Doc
   responses:
     '200':
       description: Successful Request
@@ -65,11 +62,11 @@ put:
         application/json:
           schema:
             allOf:
-            - type: object
-              properties:
-                page:
-                  $ref: ../components/schemas/wikiPage.yaml
-            - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  page:
+                    $ref: ../components/schemas/wikiPage.yaml
+              - $ref: ../components/schemas/200-success.yaml
           examples:
             Wiki Response:
               value:

--- a/paths/api@whoami.yaml
+++ b/paths/api@whoami.yaml
@@ -7,7 +7,6 @@ get:
   operationId: whoami
   tags:
     - Authentication
-    - Users
   responses:
     '200':
       description: Successful Request

--- a/paths/api@zones@id@wiki.yaml
+++ b/paths/api@zones@id@wiki.yaml
@@ -4,7 +4,6 @@ get:
     This endpoint retrieves a cloud Wiki page.
   operationId: getWikiCloud
   tags:
-    - Wiki
     - Clouds
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -35,7 +34,6 @@ put:
     Updates a cloud Wiki page.
   operationId: updateWikiCloud
   tags:
-    - Wiki
     - Clouds
   parameters:
     - $ref: ../components/parameters/id-path.yaml
@@ -48,16 +46,15 @@ put:
             page:
               type: object
               properties:
-                name: 
+                name:
                   type: string
                   example: Sample Doc
-                category: 
+                category:
                   type: string
                   example: info
-                content: 
+                content:
                   type: string
-                  example: #Sample Doc
-                    A sample document in **markdown**.`
+                  example: A sample document in **markdown**.` #Sample Doc
   responses:
     '200':
       description: Successful Request
@@ -65,11 +62,11 @@ put:
         application/json:
           schema:
             allOf:
-            - type: object
-              properties:
-                page:
-                  $ref: ../components/schemas/wikiPage.yaml
-            - $ref: ../components/schemas/200-success.yaml
+              - type: object
+                properties:
+                  page:
+                    $ref: ../components/schemas/wikiPage.yaml
+              - $ref: ../components/schemas/200-success.yaml
           examples:
             Wiki Response:
               value:


### PR DESCRIPTION
This PR is one of a series that aims to get the spec compatible with tooling that consumes it, such as OpenAPI generator to generate clients from the spec.

Having multiple tags associated with an endpoint seems to break tools which consume the API spec.

For example:
- Endpoints with multiple tags on [the Morpheus API docs page](https://apidocs.morpheusdata.com/) do not appear in more than one section. 
- OpenAPI Generator generates duplicate structs in the model code of the sections of the API listed by multiple tags on an endpoint.

The other issue here is that having a section of the API associated with multiple tags doesn't represent the actual structure of the Morpheus API or the user-facing API of the Morpheus CLI.

e.g.: the various resources which have a `Wiki` tag are not actually part of the Wiki API:

```
# morpheus wiki --help
Usage: morpheus wiki [command] [options]
Commands:
        add
        categories
        get
        list
        remove
        update
        view
```

Observe how the hosts/servers `wiki` command appears under that API, not under the wiki API:
```
# morpheus hosts --help
Usage: morpheus hosts [command] [options]
Commands:
        add
        assign-device
		...
        wiki

View and manage hosts (servers).
```

As a final note for this PR, the `whoami` endpoint has been left under `Authentication`. This is how it currently renders on the website. But it should probably be given its own `whoami` tag or similar to represent the actual API and CLI structure.