### PR TITLE
Update Rakefile with generate command and newer Redocly CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 bundled.yaml
-bundle2.yaml
+generated/
 .idea/

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,9 @@ task :test => ["docker:lint"]
 desc "Builds bundled.yaml with redocly via docker "
 task :build => ["docker:build"]
 
+desc "Generates a Go client with OpenAPI Generator via docker"
+task :generate => ["docker:generate"]
+
 namespace "docker" do
 
   # Ensure docker is installed
@@ -23,10 +26,10 @@ namespace "docker" do
   #desc "Validate the openapi schema with both redocly and spectral"
   task :lint => [:redocly_lint, :spectral_lint]
 
-  #desc "Executes `redocly/openapi-cli lint` using docker"
+  #desc "Executes `redocly/cli lint` using docker"
   task :redocly_lint => [:is_installed] do
   	cd PROJECT_ROOT, verbose: false do
-		  sh("docker run --rm -v $PWD:/spec redocly/openapi-cli lint openapi.yaml --skip-rule no-invalid-media-type-examples")
+		  sh("docker run --rm -v $PWD:/spec redocly/cli lint openapi.yaml --skip-rule no-invalid-media-type-examples")
     end
   end
 
@@ -37,11 +40,23 @@ namespace "docker" do
     end
   end
 
-  #desc "Executes `stoplight/spectral lint` using docker"
+  #desc "Executes `redocly/cli bundle` using docker"
   task :build => [:is_installed] do
     cd PROJECT_ROOT, verbose: false do
-      sh("docker run --rm -v $PWD:/spec redocly/openapi-cli bundle openapi.yaml > bundled.yaml")
+      sh("docker run --rm -v $PWD:/spec redocly/cli bundle --dereferenced openapi.yaml > bundled.yaml")
     end
   end
-end
 
+  # desc "Executes openapitools/openapi-generator-cli using docker"
+  task :generate => [:is_installed, :build] do
+    cd PROJECT_ROOT, verbose: false do
+      sh("mkdir -p generated/client-go && \
+      cp .openapi-generator/.openapi-generator-ignore generated/client-go && \
+      docker run -v $PWD:/spec -it \
+      -e JAVA_OPTS=-DmaxYamlCodePoints=999999999 \
+      openapitools/openapi-generator-cli \
+      generate -g go -i /spec/bundled.yaml -t /spec/.openapi-generator/go/templates -o /spec/generated/client-go")
+    end
+  end
+
+end


### PR DESCRIPTION
- Update the Rakefile with a `generate` command to allow for quick local generation of the same client generated in CI. This uses `openapitools/openapi-generator-cli` in Docker.
- Update the Redocly CLI image that the Rakefile uses to be `redocli/cli`. This is the newer version of the old image, `redocly/openapi-cli`.