### PR TITLE
Fix Spectral Lint failures due to ref parsing

### DIFF
--- a/.github/workflows/spectral-lint.yml
+++ b/.github/workflows/spectral-lint.yml
@@ -1,7 +1,7 @@
 # .github/workflows/spectral-lint.yml
 
 name: Run OpenAPI linters
-on: [pull_request, workflow_dispatch]
+on: [pull_request, push, workflow_dispatch]
 jobs:
   redocly-lint-openapi:
     runs-on: ubuntu-latest
@@ -16,7 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Bundle Spec
+        uses: docker://redocly/cli:latest
+        with:
+          args: bundle --dereferenced openapi.yaml -o bundled.yaml
       - name: Spectral Lint
         uses: docker://stoplight/spectral:latest
         with:
-          args: lint -v -F hint "openapi.yaml" --ruleset ".spectral.json"
+          args: lint -v -F error "bundled.yaml" --ruleset ".spectral.json"

--- a/Rakefile
+++ b/Rakefile
@@ -34,9 +34,9 @@ namespace "docker" do
   end
 
   #desc "Executes `stoplight/spectral lint` using docker"
-  task :spectral_lint => [:is_installed] do
+  task :spectral_lint => [:is_installed, :build] do
     cd PROJECT_ROOT, verbose: false do
-      sh("docker run --rm -v $PWD:/tmp -it stoplight/spectral lint -v -F hint \"/tmp/openapi.yaml\" --ruleset \"/tmp/.spectral.json\"")
+      sh("docker run --rm -v $PWD:/tmp -it stoplight/spectral lint -v -F error \"/tmp/bundled.yaml\" --ruleset \"/tmp/.spectral.json\"")
     end
   end
 


### PR DESCRIPTION
- Updates the spectral lint GitHub action file to lint a bundled spec.
- Run the spectral lint GitHub Action on `push` in addition to `pull_request` and `workflow_dispatch`
- Updates the spectral lint command in the Rakefile to lint a bundled spec.
- Change the `fail severity` (`-F`) of spectral lint to `error`. The OpenAPI spec gives many warnings of potentially unused components. I was observing unused components warnings with other tools, so I'm not sure if we need to fail linting on these.