### PR TITLE
user resource: linux key id - should be integer not string

### DIFF
--- a/paths/api@users@id.yaml
+++ b/paths/api@users@id.yaml
@@ -67,9 +67,10 @@ put:
                     - string
                   format: password
                 linuxKeyPairId:
+                  format: int64
                   type:
                     - 'null'
-                    - string
+                    - integer
                 windowsUsername:
                   type:
                     - 'null'


### PR DESCRIPTION
The API uses a number here, not a string