### PR TITLE
Add group to network

### DIFF
--- a/components/examples/network.json
+++ b/components/examples/network.json
@@ -4,6 +4,10 @@
     "name": "my-network",
     "displayName": "network display name",
     "labels": [],
+    "group": {
+      "id": 1,
+      "name": "Group"
+    },
     "zone": {
       "id": 31,
       "name": "qa-azure"

--- a/components/examples/networks.json
+++ b/components/examples/networks.json
@@ -5,6 +5,10 @@
       "name": "my-network",
       "displayName": "my-displayName",
       "labels": [],
+      "group": {
+        "id": 1,
+        "name": "Group"
+      },
       "zone": {
         "id": 5,
         "name": "qa-azure"

--- a/components/schemas/network.yaml
+++ b/components/schemas/network.yaml
@@ -16,6 +16,20 @@ properties:
       - 'null'
     items:
       type: string
+  group:
+    type:
+      - object
+      - 'null'
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Group ID
+      name:
+        type:
+          - string
+          - 'null'
+        description: Group Name
   zone:
     type: object
     properties:


### PR DESCRIPTION
This is returned by the API:

```
{
  "network": {
    "id": 123,
    .
    .
    .
    "group": {
      "id": 1,
      "name": "Group 1"
    },
```

but is missing from the spec.