### PR TITLE
network create: use resourcePermission

### DIFF
--- a/components/schemas/networkCreate.yaml
+++ b/components/schemas/networkCreate.yaml
@@ -166,7 +166,7 @@ properties:
         id:
           type: integer
           format: int64
-  resourcePermissions:
+  resourcePermission:
     type: object
     properties:
       all:


### PR DESCRIPTION
Change network create to use resourcePermission (singular) not resourcePermissions (plural).

From testing, that is what the server actually uses.