### PR TITLE
network update: use resourcePermission

### DIFF
--- a/components/schemas/networkUpdate.yaml
+++ b/components/schemas/networkUpdate.yaml
@@ -92,7 +92,7 @@ properties:
         id:
           type: integer
           format: int64
-  resourcePermissions:
+  resourcePermission:
     type: object
     properties:
       all:


### PR DESCRIPTION
Switch to resourcePermission from resourcePermissions (plural) for update.
This makes update consistent with create and get.