### PR TITLE
network: include zonePool name for GCP

### DIFF
--- a/components/examples/networkCreateSuccessGcp.json
+++ b/components/examples/networkCreateSuccessGcp.json
@@ -67,7 +67,8 @@
         "noProxy": null,
         "applianceUrlProxyBypass": true,
         "zonePool": {
-            "id": 3772
+            "id": 3772,
+            "name": "Google Labs Project Pool"
         },
         "allowStaticOverride": true,
         "subnets": [],


### PR DESCRIPTION
Add zonePool name to example GCP response (in
addition to id)