### PR TITLE
Remove extraneous 'default' enum values from Role global access levels

### DIFF
--- a/paths/api@roles.yaml
+++ b/paths/api@roles.yaml
@@ -130,7 +130,6 @@ post:
                   type: string
                   description: Set the default access level for for groups (sites). Only applies to user roles.
                   enum:
-                    - default
                     - full
                     - read
                     - none
@@ -159,7 +158,6 @@ post:
                   type: string
                   description: Set the default access level for for clouds (zones). Only applies to base account (tenant) roles.
                   enum:
-                    - default
                     - full
                     - read
                     - none


### PR DESCRIPTION
"Default" isn't a valid option for default access levels.