### PR TITLE
Add osType resource

### DIFF
--- a/components/schemas/osType.yaml
+++ b/components/schemas/osType.yaml
@@ -3,6 +3,8 @@ properties:
   id:
     type: integer
     format: int64
+  code:
+    type: string
   name:
     type: string
     description: |


### PR DESCRIPTION
This PR is to add the osType resource.

It also adds in `code` as it was missing from the GET response.