### PR TITLE
Add owner property for osType

### DIFF
--- a/components/schemas/osType.yaml
+++ b/components/schemas/osType.yaml
@@ -19,6 +19,12 @@ properties:
     type: string
     description: |
       The platform of the osType. 
+  owner:                             
+    type:                          
+      - string                     
+      - 'null'                     
+    description: |                 
+      The owner  of the osType.
   category:
     type:
       - string


### PR DESCRIPTION
This PR adds to owner to the osType.yaml

Adding in this missing property from the read.