### PR TITLE
[MORPH-5868] Add ability to cancel support bundles

### DIFF
--- a/components/schemas/supportBundle.yaml
+++ b/components/schemas/supportBundle.yaml
@@ -14,6 +14,8 @@ properties:
     enum:
       - PENDING
       - IN_PROGRESS
+      - CANCELLING
+      - CANCELLED
       - COMPLETED
       - FAILED
   statusMessage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1152,6 +1152,8 @@ paths:
     $ref: paths/api@support-bundles@id.yaml
   /api/support-bundles/{id}/download:
     $ref: paths/api@support-bundles@id@download.yaml
+  /api/support-bundles/{id}/cancel:
+    $ref: paths/api@support-bundles@id@cancel.yaml
   /api/tasks:
     $ref: paths/api@tasks.yaml
   /api/tasks/{id}:

--- a/paths/api@support-bundles@id.yaml
+++ b/paths/api@support-bundles@id.yaml
@@ -24,12 +24,19 @@ get:
 delete:
   summary: Deletes a Support Bundle
   description: |
-    Deletes a specific support bundle by ID.
+    Deletes a specific support bundle by ID. Active bundles (PENDING, IN_PROGRESS, or CANCELLING)
+    are rejected unless `force=true` is passed.
   operationId: removeSupportBundle
   tags:
     - Support Bundles
   parameters:
     - $ref: ../components/parameters/id-path.yaml
+    - name: force
+      in: query
+      required: false
+      schema:
+        type: boolean
+      description: If true, delete the bundle even if it is in an active state (PENDING, IN_PROGRESS, or CANCELLING).
   responses:
     '200':
       description: Successful Request

--- a/paths/api@support-bundles@id@cancel.yaml
+++ b/paths/api@support-bundles@id@cancel.yaml
@@ -1,0 +1,25 @@
+post:
+  summary: Cancel a Support Bundle
+  description: |
+    Cancel a specific support bundle. If the bundle is PENDING it transitions immediately to CANCELLED. If IN_PROGRESS it transitions to CANCELLING and generation stops at the next checkpoint. Returns an error if the bundle is already in a terminal state (COMPLETED or FAILED). Calling cancel on an already CANCELLING or CANCELLED bundle is a no-op success.
+  operationId: cancelSupportBundle
+  tags:
+    - Support Bundles
+  parameters:
+    - $ref: ../components/parameters/id-path.yaml
+  responses:
+    '200':
+      description: Successful Request
+      content:
+        application/json:
+          schema:
+            allOf:
+              - type: object
+                properties:
+                  supportBundle:
+                    $ref: ../components/schemas/supportBundle.yaml
+              - $ref: ../components/schemas/200-success.yaml
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
## Summary

Documents the new support bundle cancellation endpoint and updates existing specs to reflect force-delete and the expanded status enum.

## Changes

- `paths/api@support-bundles@id@cancel.yaml` — new `POST /api/support-bundles/{id}/cancel` operation; response includes the updated `supportBundle` object
- `paths/api@support-bundles@id.yaml` — DELETE now documents the `force` query parameter and its behaviour for active bundles
- `components/schemas/supportBundle.yaml` — `CANCELLING` and `CANCELLED` added to the status enum
- `openapi.yaml` — cancel path registered

## Related PRs

- morpheus-ui: https://github.com/HPE-EMU/morpheus-ui/pull/3585
- morpheus-cli: https://github.com/HewlettPackard/morpheus-cli/pull/56

## Jira

https://hpe-morpheus.atlassian.net/browse/MORPH-5868