### PR TITLE
Start implementing a load_balancer resource

### DIFF
--- a/components/schemas/loadBalancerCreate.yaml
+++ b/components/schemas/loadBalancerCreate.yaml
@@ -31,7 +31,7 @@ properties:
         description: Cloud/Zone ID
   config:
     description: Configuration object with parameters that vary by load balancer type.
-    oneOf:
+    anyOf:
       - $ref: loadBalancerCreateConfigHaproxy.yaml
       - type: object
   visibility:
@@ -59,4 +59,3 @@ properties:
         items:
           type: integer
           format: int64
-

--- a/components/schemas/loadBalancerCreate.yaml
+++ b/components/schemas/loadBalancerCreate.yaml
@@ -1,40 +1,62 @@
 type: object
-properties: 
-  name: 
+properties:
+  type:
+    type: string
+    description: Load Balancer Type Code
+  name:
     type: string
     description: Name
   description:
     type: string
     description: Description
-  networkServerId: 
+  networkServerId:
     type: integer
     format: int64
     description: Network Server ID
-  config: 
+  site:
     type: object
+    description: Group/Site reference
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Group/Site ID
+  zone:
+    type: object
+    description: Cloud/Zone reference
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Cloud/Zone ID
+  config:
     description: Configuration object with parameters that vary by load balancer type.
-  visibility: 
+    oneOf:
+      - $ref: loadBalancerCreateConfigHaproxy.yaml
+      - type: object
+  visibility:
     type: string
     description: private or public
     default: "public"
-  tenants: 
+  tenants:
     type: array
     description: Array of tenant account ids that are allowed access
-    items: 
+    items:
       type: object
-      properties: 
-        id: 
+      properties:
+        id:
           type: integer
-          format: int32
-  resourcePermission: 
+          format: int64
+  resourcePermissions:
     type: object
-    properties: 
-      all: 
+    properties:
+      all:
         type: boolean
         description: Pass true to allow access to all groups
       sites:
         type: array
         description: Array of groups that are allowed access
-        items: 
+        items:
           type: integer
           format: int64
+

--- a/components/schemas/loadBalancerCreateConfigHaproxy.yaml
+++ b/components/schemas/loadBalancerCreateConfigHaproxy.yaml
@@ -1,0 +1,19 @@
+title: HAProxy Load Balancer Config Object
+type: object
+description: Configuration object for HAProxy load balancer type.
+properties:
+  plan:
+    type: object
+    description: Service plan reference
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: Service Plan ID
+  pool:
+    type: object
+    description: Resource pool reference
+    properties:
+      id:
+        type: string
+        description: Resource Pool ID

--- a/paths/api@load-balancers.yaml
+++ b/paths/api@load-balancers.yaml
@@ -12,64 +12,62 @@ get:
     - $ref: ../components/parameters/name.yaml
     - $ref: ../components/parameters/phrase.yaml
   responses:
-    '200':
+    "200":
       description: Successful Request
       content:
         application/json:
           schema:
             allOf:
-            - type: object
-              properties:
-                loadBalancers:
-                  type: array
-                  items:
-                    $ref: ../components/schemas/loadBalancer.yaml
-            - $ref: ../components/schemas/meta.yaml
+              - type: object
+                properties:
+                  loadBalancers:
+                    type: array
+                    items:
+                      $ref: ../components/schemas/loadBalancer.yaml
+              - $ref: ../components/schemas/meta.yaml
           examples:
             Load Balancers Response:
               value:
                 $ref: ../components/examples/loadBalancers.json
-    '4XX':
+    "4XX":
       $ref: ../components/responses/4xx.yaml
-    '5XX':
+    "5XX":
       $ref: ../components/responses/5xx.yaml
-      
-post: 
+
+post:
   summary: Create a Load Balancer
   description: |
-    Available for NSX load balancers only
-
     Use this command to create a load balancer.
   operationId: createLoadBalancer
   tags:
     - Load Balancers
-  requestBody: 
-    content: 
-      application/json: 
-        schema: 
+  requestBody:
+    content:
+      application/json:
+        schema:
           type: object
           properties:
             loadBalancer:
               $ref: ../components/schemas/loadBalancerCreate.yaml
         examples:
           Load Balancer Request:
-            value: 
+            value:
               $ref: ../components/examples/loadBalancerCreate.json
   responses:
-    '200':
+    "200":
       description: Successful Response
-      content: 
-        application/json: 
+      content:
+        application/json:
           schema:
             type: object
             properties:
               loadBalancer:
                 $ref: ../components/schemas/loadBalancer.yaml
-          examples: 
+          examples:
             Load Balancers Update Success:
               value:
                 $ref: ../components/examples/loadBalancer.json
-    '4XX':
+    "4XX":
       $ref: ../components/responses/4xx.yaml
-    '5XX':
+    "5XX":
       $ref: ../components/responses/5xx.yaml

--- a/paths/api@load-balancers@id.yaml
+++ b/paths/api@load-balancers@id.yaml
@@ -7,7 +7,7 @@ get:
   parameters:
     - $ref: ../components/parameters/loadBalancerId-path.yaml
   responses:
-    '200':
+    "200":
       description: Successful Request
       content:
         application/json:
@@ -20,36 +20,34 @@ get:
             Load Balancers Response:
               value:
                 $ref: ../components/examples/loadBalancer.json
-    '4XX':
+    "4XX":
       $ref: ../components/responses/4xx.yaml
-    '5XX':
+    "5XX":
       $ref: ../components/responses/5xx.yaml
-      
-put: 
+
+put:
   summary: Update a Load Balancer
   description: |
-    Available for NSX load balancers only
-
     Use this command to update an existing load balancer.
   operationId: updateLoadBalancer
   tags:
     - Load Balancers
   parameters:
     - $ref: ../components/parameters/loadBalancerId-path.yaml
-  requestBody: 
-    content: 
-      application/json: 
-        schema: 
+  requestBody:
+    content:
+      application/json:
+        schema:
           type: object
-          properties: 
+          properties:
             loadBalancer:
               $ref: ../components/schemas/loadBalancerUpdate.yaml
-        examples: 
+        examples:
           Load Balancer Update Request:
             value:
               $ref: ../components/examples/loadBalancerUpdate.json
   responses:
-    '200':
+    "200":
       description: Successful Request
       content:
         application/json:
@@ -58,17 +56,17 @@ put:
             properties:
               loadBalancer:
                 $ref: ../components/schemas/loadBalancer.yaml
-          examples: 
+          examples:
             Load Balancers Update Success:
               value:
                 $ref: ../components/examples/loadBalancer.json
 
-    '4XX':
+    "4XX":
       $ref: ../components/responses/4xx.yaml
-    '5XX':
+    "5XX":
       $ref: ../components/responses/5xx.yaml
 
-delete: 
+delete:
   summary: Delete a Load Balancer
   description: Will delete a Load Balancer from the system and make it no longer usable.
   operationId: deleteLoadBalancer
@@ -77,7 +75,7 @@ delete:
   parameters:
     - $ref: ../components/parameters/loadBalancerId-path.yaml
   responses:
-    '200':
+    "200":
       description: Successful Request
       content:
         application/json:
@@ -86,8 +84,8 @@ delete:
           examples:
             Response:
               value:
-                $ref: ../components/examples/success.json 
-    '4XX':
+                $ref: ../components/examples/success.json
+    "4XX":
       $ref: ../components/responses/4xx.yaml
-    '5XX':
+    "5XX":
       $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
This PR makes various changes to enable the creation of a HAProxy load balancer.

It implements a static config block which will be used in the TF provider as `config_haproxy`