### PR TITLE
Add dynamic config to network_dhcp_server

### DIFF
--- a/components/schemas/networkDhcpServer.yaml
+++ b/components/schemas/networkDhcpServer.yaml
@@ -20,13 +20,10 @@ externalId:
   type: string
 config: 
   type: object
-  properties: 
-    edgeCluster: 
-      type: string
-    preferredEdgeNode1: 
-      type: string
-    preferredEdgeNode2: 
-      type: string
+  description: Configuration object with parameters that vary by type.
+  anyOf:
+    - $ref: networkDhcpServerConfigNSX.yaml
+    - $ref: networkDhcpServerConfigGeneric.yaml
 owner: 
   type: object
   properties: 

--- a/components/schemas/networkDhcpServerConfigGeneric.yaml
+++ b/components/schemas/networkDhcpServerConfigGeneric.yaml
@@ -1,0 +1,2 @@
+title: Generic DHCP Server Configuration
+type: object

--- a/components/schemas/networkDhcpServerConfigNSX.yaml
+++ b/components/schemas/networkDhcpServerConfigNSX.yaml
@@ -1,0 +1,13 @@
+title: NSX DHCP Server Configuration
+type: object
+description: Configuration for NSX-T DHCP servers.
+properties:
+  edgeCluster:
+    type: string
+    description: Edge Cluster
+  preferredEdgeNode1:
+    type: string
+    description: Active Edge Node Options obtained by calling option source with :optionSource = nsxtEdgeNodes and networkServerId param
+  preferredEdgeNode2:
+    type: string
+    description: Standby Edge Node Options obtained by calling option source with optionSource = nsxtEdgeNodes and networkServerId param

--- a/components/schemas/networkDhcpServerCreate.yaml
+++ b/components/schemas/networkDhcpServerCreate.yaml
@@ -18,14 +18,7 @@ properties:
     description: Name
   config:
     type: object
-    description: Configuration object with parameters that vary by pool type.
-    properties:
-      edgeCluster:
-        type: string
-        description: Edge Cluster
-      preferredEdgeNode1:
-        type: string
-        description: Active Edge Node Options obtained by calling option source with :optionSource = nsxtEdgeNodes and networkServerId param
-      preferredEdgeNode2:
-        type: string
-        description: Standby Edge Node Options obtained by calling option source with optionSource = nsxtEdgeNodes and networkServerId param
+    description: Configuration object with parameters that vary by type.
+    anyOf:
+      - $ref: networkDhcpServerConfigNSX.yaml
+      - $ref: networkDhcpServerConfigGeneric.yaml


### PR DESCRIPTION
This PR aims to make the config block in `network_dhcp_server` dynamic.