### PR TITLE
Defining networkDhcpServer schema as an object type

### DIFF
--- a/components/schemas/networkDhcpServer.yaml
+++ b/components/schemas/networkDhcpServer.yaml
@@ -1,6 +1,6 @@
 id: 
   type: integer
-  format: int32
+  format: int64
 dateCreated: 
   type: string
   format: date-time
@@ -13,7 +13,7 @@ lastUpdated:
   format: date-time
 leaseTime: 
   type: integer
-  format: int32
+  format: int64
 name: 
   type: string
 externalId: 
@@ -29,10 +29,10 @@ owner:
   properties: 
     id: 
       type: integer
-      format: int32
+      format: int64
 networkServer: 
   type: object
   properties: 
     id: 
       type: integer
-      format: int32
+      format: int64

--- a/components/schemas/networkDhcpServer.yaml
+++ b/components/schemas/networkDhcpServer.yaml
@@ -1,38 +1,40 @@
-id: 
-  type: integer
-  format: int64
-dateCreated: 
-  type: string
-  format: date-time
-providerId: 
-  type: string
-serverIpAddress: 
-  type: string
-lastUpdated: 
-  type: string
-  format: date-time
-leaseTime: 
-  type: integer
-  format: int64
-name: 
-  type: string
-externalId: 
-  type: string
-config: 
-  type: object
-  description: Configuration object with parameters that vary by type.
-  anyOf:
-    - $ref: networkDhcpServerConfigNSX.yaml
-    - $ref: networkDhcpServerConfigGeneric.yaml
-owner: 
-  type: object
-  properties: 
-    id: 
-      type: integer
-      format: int64
-networkServer: 
-  type: object
-  properties: 
-    id: 
-      type: integer
-      format: int64
+type: object
+properties:
+  id: 
+    type: integer
+    format: int64
+  dateCreated: 
+    type: string
+    format: date-time
+  providerId: 
+    type: string
+  serverIpAddress: 
+    type: string
+  lastUpdated: 
+    type: string
+    format: date-time
+  leaseTime: 
+    type: integer
+    format: int64
+  name: 
+    type: string
+  externalId: 
+    type: string
+  config: 
+    type: object
+    description: Configuration object with parameters that vary by type.
+    anyOf:
+      - $ref: networkDhcpServerConfigNSX.yaml
+      - $ref: networkDhcpServerConfigGeneric.yaml
+  owner: 
+    type: object
+    properties: 
+      id: 
+        type: integer
+        format: int64
+  networkServer: 
+    type: object
+    properties: 
+      id: 
+        type: integer
+        format: int64

--- a/paths/api@networks@servers@id@dhcp-servers.yaml
+++ b/paths/api@networks@servers@id@dhcp-servers.yaml
@@ -22,10 +22,9 @@ get:
             - type: object
               properties:
                 networkDhcpServers:
+                  type: array
                   items:
-                    type: object
-                    properties:
-                      $ref: ../components/schemas/networkDhcpServer.yaml
+                    $ref: ../components/schemas/networkDhcpServer.yaml
             - $ref: ../components/schemas/meta.yaml
           examples:
             Networks Response:

--- a/paths/api@networks@servers@id@dhcp-servers@id.yaml
+++ b/paths/api@networks@servers@id@dhcp-servers@id.yaml
@@ -17,8 +17,7 @@ get:
             type: object
             properties:
               networkDhcpServer:
-                properties:
-                  $ref: ../components/schemas/networkDhcpServer.yaml
+                $ref: ../components/schemas/networkDhcpServer.yaml
           examples:
             Networks Response:
               value:


### PR DESCRIPTION
This PR aims to fix the format of the schema, which was missing an type header, for the `network_dhcp_server` resource/datasource.
 
 Drive by: Fix array defintion in paths