### PR TITLE
Defining the ruleGroups type

### DIFF
--- a/paths/api@networks@servers@id@firewall-rule-groups.yaml
+++ b/paths/api@networks@servers@id@firewall-rule-groups.yaml
@@ -22,6 +22,7 @@ get:
             - type: object
               properties:
                 ruleGroups:
+                  type: array
                   items:
                     type: object
                     properties:


### PR DESCRIPTION
This PR aims to define the `ruleGroups` as an array under the 200 response.