### PR TITLE
MORPH-10387: Add showHidden support to network server API docs and query handling

### DIFF
--- a/components/parameters/showHidden.yaml
+++ b/components/parameters/showHidden.yaml
@@ -1,0 +1,6 @@
+name: showHidden
+in: query
+description: If true, includes hidden network servers in the response.
+schema:
+  type: boolean
+example: true

--- a/paths/api@networks@servers.yaml
+++ b/paths/api@networks@servers.yaml
@@ -12,6 +12,7 @@ get:
     - $ref: ../components/parameters/direction.yaml
     - $ref: ../components/parameters/phrase.yaml
     - $ref: ../components/parameters/name.yaml
+    - $ref: ../components/parameters/showHidden.yaml
   responses:
     '200':
       description: Successful Request


### PR DESCRIPTION
**Summary**

- Added showHidden support for GET /api/networks/servers.
- Hidden network servers remain excluded by default and are included when showHidden=true.
- Updated OpenAPI docs and added service-level test coverage for the query logic.