### PR TITLE
add typed BGP neighbor schemas for create/update/read

### DIFF
--- a/components/examples/networkRouterBgpNeighborCreate.json
+++ b/components/examples/networkRouterBgpNeighborCreate.json
@@ -1,11 +1,6 @@
 {
   "networkRouterBgpNeighbor": {
     "ipAddress": "172.16.2.23",
-    "config": {
-        "sourceAddresses": [
-            "10.22.12.2"
-        ]
-    },
     "remoteAs": "21346",
     "keepAlive": 60,
     "holdDown": 180,
@@ -17,6 +12,11 @@
     "bfdMultiple": 3,
     "allowAsIn": "off",
     "hopLimit": 1,
-    "restartMode": "HELPER_ONLY"
+    "restartMode": "HELPER_ONLY",
+    "config": {
+      "sourceAddresses": [
+        "10.22.12.2"
+      ]
+    }
   }
 }

--- a/components/parameters/routerId-path.yaml
+++ b/components/parameters/routerId-path.yaml
@@ -3,5 +3,6 @@ in: path
 description: Router ID
 required: true
 schema:
-  type: number
+  type: integer
+  format: int64
 example: 4

--- a/components/schemas/networkRouterBgpNeighbor.yaml
+++ b/components/schemas/networkRouterBgpNeighbor.yaml
@@ -3,6 +3,10 @@ id:
   format: int64
 ipAddress:
   type: string
+description:
+  type:
+    - string
+    - 'null'
 forwardingAddress:
   type:
     - string
@@ -26,52 +30,79 @@ password:
   type:
     - string
     - 'null'
+passwordHash:
+  type:
+    - string
+    - 'null'
 routeFilteringType:
-  type: string
+  type:
+    - string
+    - 'null'
 routeFilteringIn:
-  type: string
+  type:
+    - string
+    - 'null'
 routeFilteringOut:
-  type: string
+  type:
+    - string
+    - 'null'
 bfdEnabled:
-  type: boolean
+  type:
+    - boolean
+    - 'null'
 bfdInterval:
-  type: integer
+  type:
+    - integer
+    - 'null'
   format: int64
 bfdMultiple:
-  type: integer
+  type:
+    - integer
+    - 'null'
   format: int64
 allowAsIn:
-  type: boolean
+  type:
+    - boolean
+    - 'null'
 hopLimit:
-  type: integer
+  type:
+    - integer
+    - 'null'
   format: int64
 restartMode:
-  type: string
+  type:
+    - string
+    - 'null'
 providerId:
-  type: string
+  type:
+    - string
+    - 'null'
 syncSource:
-  type: string
+  type:
+    - string
+    - 'null'
 internalId:
   type:
     - string
     - 'null'
 externalId:
-  type: string
+  type:
+    - string
+    - 'null'
 refType:
   type:
     - string
     - 'null'
 refId:
   type:
-    - string
+    - integer
     - 'null'
+  format: int64
 config:
-  type: object
-  properties:
-    sourceAddresses:
-      type: array
-      items:
-        type: string
+  anyOf:
+    - $ref: networkRouterBgpNeighborConfigNsxt.yaml
+    - $ref: networkRouterBgpNeighborConfigNsxv.yaml
+    - $ref: networkRouterBgpNeighborConfigGeneric.yaml
 dateCreated:
   type: string
   format: date-time

--- a/components/schemas/networkRouterBgpNeighborConfigGeneric.yaml
+++ b/components/schemas/networkRouterBgpNeighborConfigGeneric.yaml
@@ -1,0 +1,4 @@
+title: Generic BGP Neighbor Config
+description: Freeform configuration for other router types
+type: object
+additionalProperties: true

--- a/components/schemas/networkRouterBgpNeighborConfigNsxt.yaml
+++ b/components/schemas/networkRouterBgpNeighborConfigNsxt.yaml
@@ -1,0 +1,9 @@
+title: NSX-T BGP Neighbor Config
+description: Configuration for NSX-T Tier-0/Tier-1 router BGP neighbors
+type: object
+properties:
+  sourceAddresses:
+    type: array
+    description: Source IP addresses for the BGP session
+    items:
+      type: string

--- a/components/schemas/networkRouterBgpNeighborConfigNsxtCreate.yaml
+++ b/components/schemas/networkRouterBgpNeighborConfigNsxtCreate.yaml
@@ -1,0 +1,9 @@
+title: NSX-T BGP Neighbor Config
+description: Configuration for NSX-T Tier-0/Tier-1 router BGP neighbors
+type: object
+properties:
+  sourceAddresses:
+    type: array
+    description: Source IP addresses for the BGP session
+    items:
+      type: string

--- a/components/schemas/networkRouterBgpNeighborConfigNsxv.yaml
+++ b/components/schemas/networkRouterBgpNeighborConfigNsxv.yaml
@@ -1,0 +1,10 @@
+title: NSX-V BGP Neighbor Config
+description: Configuration for NSX-V Edge router BGP neighbors
+type: object
+properties:
+  routerId:
+    type: string
+    description: The router identifier
+  interface:
+    type: string
+    description: The interface name for the BGP session

--- a/components/schemas/networkRouterBgpNeighborConfigNsxvCreate.yaml
+++ b/components/schemas/networkRouterBgpNeighborConfigNsxvCreate.yaml
@@ -1,0 +1,10 @@
+title: NSX-V BGP Neighbor Config
+description: Configuration for NSX-V Edge/Distributed router BGP neighbors
+type: object
+properties:
+  routerId:
+    type: string
+    description: The router identifier (auto-populated for edge routers)
+  interface:
+    type: string
+    description: The interface name for the BGP session (distributed routers only)

--- a/components/schemas/networkRouterBgpNeighborCreate.yaml
+++ b/components/schemas/networkRouterBgpNeighborCreate.yaml
@@ -50,7 +50,6 @@ properties:
       - boolean
       - string
     description: Enable BFD (Bidirectional Forwarding Detection). Accepts true/false or "on"/"off"
-    default: false
   bfdInterval:
     type: integer
     format: int64
@@ -64,7 +63,6 @@ properties:
       - boolean
       - string
     description: Allow AS-in. Accepts true/false or "on"/"off"
-    default: false
   hopLimit:
     type: integer
     format: int64

--- a/components/schemas/networkRouterBgpNeighborCreate.yaml
+++ b/components/schemas/networkRouterBgpNeighborCreate.yaml
@@ -1,0 +1,80 @@
+type: object
+required:
+  - ipAddress
+description: Payload for creating a network router BGP neighbor. Available fields depend on the router type's bgpOptionTypes.
+properties:
+  ipAddress:
+    type: string
+    description: IP address of the BGP neighbor
+  description:
+    type: string
+    description: Description of the BGP neighbor
+  forwardingAddress:
+    type: string
+    description: Forwarding address (NSX-V distributed router)
+  protocolAddress:
+    type: string
+    description: Protocol address (NSX-V distributed router)
+  remoteAs:
+    type: string
+    description: Remote AS number
+  weight:
+    type: integer
+    format: int64
+    description: Route weight
+    default: 60
+  keepAlive:
+    type: integer
+    format: int64
+    description: Keep-alive interval in seconds
+    default: 60
+  holdDown:
+    type: integer
+    format: int64
+    description: Hold-down timer in seconds
+    default: 180
+  password:
+    type: string
+    description: BGP session password
+  routeFilteringType:
+    type: string
+    description: Address family for route filtering (e.g. IPV4, IPV6)
+  routeFilteringIn:
+    type: string
+    description: Inbound route filter name
+  routeFilteringOut:
+    type: string
+    description: Outbound route filter name
+  bfdEnabled:
+    type:
+      - boolean
+      - string
+    description: Enable BFD (Bidirectional Forwarding Detection). Accepts true/false or "on"/"off"
+    default: false
+  bfdInterval:
+    type: integer
+    format: int64
+    description: BFD interval in milliseconds
+  bfdMultiple:
+    type: integer
+    format: int64
+    description: BFD multiplier
+  allowAsIn:
+    type:
+      - boolean
+      - string
+    description: Allow AS-in. Accepts true/false or "on"/"off"
+    default: false
+  hopLimit:
+    type: integer
+    format: int64
+    description: Maximum hop limit
+    default: 1
+  restartMode:
+    type: string
+    description: Graceful restart mode (e.g. HELPER_ONLY, GRACEFUL_RESTART, DISABLE)
+  config:
+    anyOf:
+      - $ref: networkRouterBgpNeighborConfigNsxtCreate.yaml
+      - $ref: networkRouterBgpNeighborConfigNsxvCreate.yaml
+      - $ref: networkRouterBgpNeighborConfigGeneric.yaml

--- a/components/schemas/networkRouterBgpNeighborUpdate.yaml
+++ b/components/schemas/networkRouterBgpNeighborUpdate.yaml
@@ -1,0 +1,72 @@
+type: object
+description: Payload for updating a network router BGP neighbor. Available fields depend on the router type's bgpOptionTypes.
+properties:
+  ipAddress:
+    type: string
+    description: IP address of the BGP neighbor
+  description:
+    type: string
+    description: Description of the BGP neighbor
+  forwardingAddress:
+    type: string
+    description: Forwarding address (NSX-V distributed router)
+  protocolAddress:
+    type: string
+    description: Protocol address (NSX-V distributed router)
+  remoteAs:
+    type: string
+    description: Remote AS number
+  weight:
+    type: integer
+    format: int64
+    description: Route weight
+  keepAlive:
+    type: integer
+    format: int64
+    description: Keep-alive interval in seconds
+  holdDown:
+    type: integer
+    format: int64
+    description: Hold-down timer in seconds
+  password:
+    type: string
+    description: BGP session password
+  routeFilteringType:
+    type: string
+    description: Address family for route filtering (e.g. IPV4, IPV6)
+  routeFilteringIn:
+    type: string
+    description: Inbound route filter name
+  routeFilteringOut:
+    type: string
+    description: Outbound route filter name
+  bfdEnabled:
+    type:
+      - boolean
+      - string
+    description: Enable BFD (Bidirectional Forwarding Detection). Accepts true/false or "on"/"off"
+  bfdInterval:
+    type: integer
+    format: int64
+    description: BFD interval in milliseconds
+  bfdMultiple:
+    type: integer
+    format: int64
+    description: BFD multiplier
+  allowAsIn:
+    type:
+      - boolean
+      - string
+    description: Allow AS-in. Accepts true/false or "on"/"off"
+  hopLimit:
+    type: integer
+    format: int64
+    description: Maximum hop limit
+  restartMode:
+    type: string
+    description: Graceful restart mode (e.g. HELPER_ONLY, GRACEFUL_RESTART, DISABLE)
+  config:
+    anyOf:
+      - $ref: networkRouterBgpNeighborConfigNsxtCreate.yaml
+      - $ref: networkRouterBgpNeighborConfigNsxvCreate.yaml
+      - $ref: networkRouterBgpNeighborConfigGeneric.yaml

--- a/paths/api@networks@routers@id@bgp-neighbors.yaml
+++ b/paths/api@networks@routers@id@bgp-neighbors.yaml
@@ -44,8 +44,7 @@ post:
           type: object
           properties: 
             networkRouterBgpNeighbor:
-              type: object
-              description: For a full list of available options, see bgpOptionTypes in the specific Network Router Type
+              $ref: ../components/schemas/networkRouterBgpNeighborCreate.yaml
         examples: 
           Network Router BGP Neighbor Request:
             value:

--- a/paths/api@networks@routers@id@bgp-neighbors@id.yaml
+++ b/paths/api@networks@routers@id@bgp-neighbors@id.yaml
@@ -44,8 +44,7 @@ put:
           type: object
           properties: 
             networkRouterBgpNeighbor:
-              type: object
-              description: For a full list of available BGP Neighbor options, see bgpOptionTypes in the specific Network Router Type
+              $ref: ../components/schemas/networkRouterBgpNeighborUpdate.yaml
         examples: 
           Network Router BGP Neighbor Request:
             value:


### PR DESCRIPTION
Add typed BGP neighbor schemas with anyOf config variants (NSX-T, NSX-V, generic) for create, update, and read operations.
