### PR TITLE
RouteID format change to int64

### DIFF
--- a/components/parameters/routeId-path.yaml
+++ b/components/parameters/routeId-path.yaml
@@ -3,5 +3,7 @@ in: path
 description: The ID of the route
 required: true
 schema:
-  type: number
+  type: integer
+  format: int64
+  description: Route ID
 example: 4

--- a/components/schemas/networkFirewallRule.yaml
+++ b/components/schemas/networkFirewallRule.yaml
@@ -1,6 +1,6 @@
 id:
   type: integer
-  format: int32
+  format: int64
 direction:
   type: string
 sourceType:
@@ -13,7 +13,7 @@ policy:
   type: string
 priority:
   type: integer
-  format: int32
+  format: int64
 enabled:
   type: boolean
 ruleGroup:
@@ -21,7 +21,7 @@ ruleGroup:
   properties:
     id:
       type: integer
-      format: int32
+      format: int64
     name:
       type: string
 groupName:


### PR DESCRIPTION
This PR aims to define the format and type for `routeId`.

Drive by: Updating networkFirewallRule int32 to int64.