### PR TITLE
Fixes for network router route MTU

### DIFF
--- a/components/examples/networkRouterRouteCreate.json
+++ b/components/examples/networkRouterRouteCreate.json
@@ -6,6 +6,6 @@
     "defaultRoute": false,
     "source": "99.99.99.99",
     "destination": "88.88.88.88",
-    "networkMtu": "65535"
+    "networkMtu": 65535,
   }
 }

--- a/components/schemas/networkRouterRoute.yaml
+++ b/components/schemas/networkRouterRoute.yaml
@@ -31,8 +31,9 @@ properties:
     type: boolean
   networkMtu:
     type:
-      - string
+      - number
       - 'null'
+      format: int64
   externalInterface:
     type:
       - string

--- a/components/schemas/networkRouterRoute.yaml
+++ b/components/schemas/networkRouterRoute.yaml
@@ -33,7 +33,7 @@ properties:
     type:
       - number
       - 'null'
-      format: int64
+    format: int64
   externalInterface:
     type:
       - string

--- a/components/schemas/networkRouterRouteCreate.yaml
+++ b/components/schemas/networkRouterRouteCreate.yaml
@@ -2,7 +2,6 @@ type: object
 required:
   - source
   - destination
-  - networkMtu
 properties:
   name:
     type: string
@@ -25,5 +24,6 @@ properties:
     type: string
     description: Destination address or range
   networkMtu:
-    type: string
+    type: number
+    format: int64
     description: MTU


### PR DESCRIPTION
It's a number, not a string. It's not required on POST.
