### PR TITLE
Fix network firewall rule group OpenAPI schema

### DIFF
--- a/components/examples/networkFirewallRule.json
+++ b/components/examples/networkFirewallRule.json
@@ -5,6 +5,7 @@
     "sourceType": "cidr",
     "destinationType": "instance",
     "name": "stubby-toes-rule-1",
+    "description": null,
     "policy": "accept",
     "priority": 0,
     "enabled": true,

--- a/components/examples/networkFirewallRules.json
+++ b/components/examples/networkFirewallRules.json
@@ -6,6 +6,7 @@
       "sourceType": "cidr",
       "destinationType": "instance",
       "name": "stubby-toes-rule-1",
+      "description": null,
       "policy": "accept",
       "priority": 0,
       "enabled": true,

--- a/components/schemas/networkFirewallRule.yaml
+++ b/components/schemas/networkFirewallRule.yaml
@@ -9,6 +9,10 @@ destinationType:
   type: string
 name:
   type: string
+description:
+  type:
+    - string
+    - 'null'
 policy:
   type: string
 priority:

--- a/components/schemas/networkFirewallRuleCreate.yaml
+++ b/components/schemas/networkFirewallRuleCreate.yaml
@@ -22,8 +22,9 @@ properties:
     description: Use this to set enabled state
   priority:
     type:
-      - string
+      - integer
       - 'null'
+    format: int64
     description: Network firewall rule priority
   direction:
     type: string

--- a/components/schemas/networkFirewallRuleUpdate.yaml
+++ b/components/schemas/networkFirewallRuleUpdate.yaml
@@ -1,0 +1,61 @@
+type: object
+properties:
+  ruleGroup:
+    type: object
+    properties:
+      id:
+        description: Firewall rule group for rule (*applicable to select network servers).
+        type: integer
+        format: int32
+  name:
+    type: string
+    description: Network firewall rule name
+  description:
+    type:
+      - string
+      - 'null'
+    description: Network firewall rule description
+  enabled:
+    type: boolean
+    description: Use this to set enabled state
+  priority:
+    type:
+      - string
+      - 'null'
+    description: Network firewall rule priority
+  direction:
+    type: string
+  sources:
+    type: object
+    properties:
+      id:
+        type: array
+        items:
+          type: string
+  destinations:
+    type: object
+    properties:
+      id:
+        type: array
+        items:
+          type: string
+  config:
+    type: object
+    properties:
+      application:
+        type: array
+        items:
+          type: string
+      profile:
+        type: array
+        items:
+          type: string
+  scopes:
+    type: object
+    properties:
+      id:
+        type: array
+        items:
+          type: string
+  policy:
+    type: string

--- a/components/schemas/networkFirewallRuleUpdate.yaml
+++ b/components/schemas/networkFirewallRuleUpdate.yaml
@@ -20,8 +20,9 @@ properties:
     description: Use this to set enabled state
   priority:
     type:
-      - string
+      - integer
       - 'null'
+    format: int64
     description: Network firewall rule priority
   direction:
     type: string

--- a/paths/api@networks@servers@id@firewall-rule-groups@id.yaml
+++ b/paths/api@networks@servers@id@firewall-rule-groups@id.yaml
@@ -17,6 +17,7 @@ get:
             type: object
             properties:
               ruleGroup:
+                type: object
                 properties:
                   $ref: ../components/schemas/networkFirewallRuleGroup.yaml
           examples:
@@ -47,6 +48,21 @@ put:
           properties: 
             ruleGroup:
               type: object
+              properties:
+                name:
+                  type: string
+                  description: Network firewall rule group name
+                description:
+                  type:
+                    - string
+                    - 'null'
+                  description: Network firewall rule group description
+                priority:
+                  type:
+                    - integer
+                    - 'null'
+                  format: int64
+                  description: Network firewall rule group priority
         examples: 
           Network Firewall Rule Group:
             value:

--- a/paths/api@networks@servers@id@firewall-rules@id.yaml
+++ b/paths/api@networks@servers@id@firewall-rules@id.yaml
@@ -17,6 +17,7 @@ get:
             type: object
             properties:
               rule:
+                type: object
                 properties:
                   $ref: ../components/schemas/networkFirewallRule.yaml
           examples:
@@ -47,7 +48,7 @@ put:
             The parameters for update a Network Firewall Rule is type dependent. The following lists the common parameters. Get a specific network type to list available options for the network relay type.
           properties: 
             rule:
-              type: object
+              $ref: ../components/schemas/networkFirewallRuleUpdate.yaml
         examples: 
           Network Firewall Rule Request:
             value:


### PR DESCRIPTION
## Summary

- Add missing \`type: object\` on \`ruleGroup\` property in the GET single firewall rule group response schema, fixing code generation issues
- Replace free-form \`ruleGroup: object\` in the PUT update request body with typed properties (\`name\`, \`description\`, \`priority\`) to match what the controller actually accepts

These changes align the spec with the actual morpheus-ui \`NetworkFirewallRulesController.updateGroup()\` behavior and improve SDK code generation for the HPE Terraform provider.