### PR TITLE
Fix missing type: array on firewall rules list endpoint

### DIFF
--- a/paths/api@networks@servers@id@firewall-rules.yaml
+++ b/paths/api@networks@servers@id@firewall-rules.yaml
@@ -22,6 +22,7 @@ get:
             - type: object
               properties:
                 rules:
+                  type: array
                   items:
                     type: object
                     properties:


### PR DESCRIPTION
## Summary

- Adds missing \`type: array\` to the \`rules\` property in the GET \`/api/networks/servers/{id}/firewall-rules\` response schema

## Problem

The \`rules\` property in the list response had \`items:\` defined but was missing \`type: array\`. This caused the OpenAPI SDK code generator to produce \`interface{}\` instead of a typed slice (\`[]NetworkFirewallRule\`), forcing consumers (e.g. the Terraform provider) to do a JSON marshal/unmarshal round-trip to access rule data.

## Related

- Terraform provider PR: https://github.com/HewlettPackard/hpe-morpheus-terraform-provider/pull/1124