### PR TITLE
Add load balancer pool create schema: missing fields + typed NSX-T config

### DIFF
--- a/components/schemas/loadBalancerPoolCreate.yaml
+++ b/components/schemas/loadBalancerPoolCreate.yaml
@@ -11,6 +11,21 @@ minActive:
   type: integer
   format: int64
   description: Min Active Members
+port:
+  type: integer
+  format: int64
+  description: Port number
+vipSticky:
+  type: string
+  description: Session persistence mode
+vipClientIpMode:
+  type: string
+  description: VIP client IP mode
+partition:
+  type: string
+  description: Partition
 config:
-  type: object
   description: Configuration object with parameters that vary by type.
+  anyOf:
+    - $ref: loadBalancerPoolCreateConfigNSXT.yaml
+    - $ref: loadBalancerPoolCreateConfigGeneric.yaml

--- a/components/schemas/loadBalancerPoolCreateConfigGeneric.yaml
+++ b/components/schemas/loadBalancerPoolCreateConfigGeneric.yaml
@@ -1,0 +1,3 @@
+title: Load Balancer Pool Config Object
+type: object
+description: Configuration object with parameters that vary by type.

--- a/components/schemas/loadBalancerPoolCreateConfigNSXT.yaml
+++ b/components/schemas/loadBalancerPoolCreateConfigNSXT.yaml
@@ -1,0 +1,69 @@
+title: NSX-T Load Balancer Pool Config Object
+type: object
+description: Configuration object for NSX-T load balancer pool type.
+properties:
+  activeMonitorPaths:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: |-
+      The ID of the active health monitor (NetworkLoadBalancerMonitor).
+      The Options API `/api/options/nsxt/nsxtLBPoolActiveMonitor?loadBalancerId={id}` can be used to see which options are available.
+  passiveMonitorPath:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: |-
+      The ID of the passive health monitor (NetworkLoadBalancerMonitor).
+      The Options API `/api/options/nsxt/nsxtLBPoolPassiveMonitor?loadBalancerId={id}` can be used to see which options are available.
+  snatTranslationType:
+    type: string
+    description: SNAT translation type. Determines how source NAT is applied to pool traffic.
+    enum:
+      - LBSnatDisabled
+      - LBSnatAutoMap
+      - LBSnatIpPool
+  snatIpAddresses:
+    type: array
+    description: List of SNAT IP addresses. Required when snatTranslationType is LBSnatIpPool.
+    items:
+      type: string
+  tcpMultiplexing:
+    type: boolean
+    description: Whether TCP multiplexing is enabled for the pool.
+  tcpMultiplexingNumber:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Maximum number of TCP multiplexing connections. Defaults to 6.
+  memberGroup:
+    type:
+      - object
+      - 'null'
+    description: NSX-T member group configuration. When set, pool membership is determined by group membership instead of explicit nodes.
+    properties:
+      path:
+        type: string
+        description: NSX-T member group path.
+      ipRevisionFilter:
+        type: string
+        description: IP revision filter for the member group.
+        enum:
+          - IPV4
+          - IPV6
+          - IPV4_IPV6
+      maxIpListSize:
+        type:
+          - integer
+          - 'null'
+        format: int64
+        description: Maximum IP list size for the member group.
+      port:
+        type:
+          - integer
+          - 'null'
+        format: int64
+        description: Port number for the member group.


### PR DESCRIPTION
## Summary

Add missing writable properties and typed NSX-T configuration to the load balancer pool create schema, enabling the Terraform provider to generate a fully typed Go SDK for pool CRUD operations.

## Changes

### Modified
- **`components/schemas/loadBalancerPoolCreate.yaml`**
  - Added 4 missing writable properties: `port` (int64), `vipSticky` (string), `vipClientIpMode` (string), `partition` (string)
  - Replaced untyped `config: { type: object }` with polymorphic `anyOf` referencing two new schema files

### New Files
- **`components/schemas/loadBalancerPoolCreateConfigNSXT.yaml`** — Full NSX-T pool config schema with:
  - `activeMonitorPaths` / `passiveMonitorPath` — health monitor IDs (nullable int64)
  - `snatTranslationType` — enum: `LBSnatDisabled`, `LBSnatAutoMap`, `LBSnatIpPool`
  - `snatIpAddresses` — array of strings (required when SNAT type is `LBSnatIpPool`)
  - `tcpMultiplexing` (bool) / `tcpMultiplexingNumber` (nullable int64)
  - `memberGroup` — nested nullable object with `path`, `ipRevisionFilter` (enum), `maxIpListSize`, `port`

- **`components/schemas/loadBalancerPoolCreateConfigGeneric.yaml`** — Bare `type: object` fallback for non-NSX-T load balancer types

## Why

The existing `loadBalancerPoolCreate` schema was missing `port`, `vipSticky`, `vipClientIpMode`, and `partition` — all of which are accepted by the Morpheus API (verified against `morpheus-ui` source: `NetworkLoadBalancerPoolController` and `NetworkLoadBalancerService`). The `config` field was an opaque `type: object`, which prevented the SDK code generator from producing typed structs for NSX-T config properties.

## Downstream Impact

- **hpe-morpheus-go-sdk**: Regeneration produces typed `NSXTLoadBalancerPoolConfigObject` and `NSXTLoadBalancerPoolConfigObject1` structs with proper getters/setters
- **terraform-provider-hpe**: Enables static `config_nsxt` block with validation + generic `config` dynamic fallback with `conflicts_with`

## Validation

- Cross-referenced against `morpheus-ui` Grails source (`NetworkLoadBalancerPoolController.groovy`, `NetworkLoadBalancerService.groovy`)
- SDK regenerated and compiles cleanly
- Provider builds, lints, and passes tests with these schema changes