### PR TITLE
Add subnet to instance server interface read schema

### DIFF
--- a/components/examples/instance.json
+++ b/components/examples/instance.json
@@ -467,7 +467,10 @@
                                 "id": 57802,
                                 "name": "labs_public_1a (subnet-25a65d40)"
                             },
-                            "subnet": null,
+                            "subnet": {
+                                "id": 245,
+                                "name": "labs_public_1a"
+                            },
                             "networkGroup": {
                                 "id": 2,
                                 "name": "Demo Preferred"

--- a/components/schemas/instance.yaml
+++ b/components/schemas/instance.yaml
@@ -1147,6 +1147,14 @@ properties:
                         format: int64
                       name:
                         type: string
+                  subnet:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
+                      name:
+                        type: string
                   networkGroup:
                     type: object
                     properties:


### PR DESCRIPTION
## What

Adds `subnet { id, name }` to the instance GET server-interface read schema (`containerDetails.server.interfaces[]`), alongside the existing `network` / `networkGroup` / `networkPool`.

## Why

The API already returns this field — `_computeServerInterface.gson` serialises `subnet` for every server interface — but the OpenAPI schema omitted it, so the generated SDK had no `subnet` on the interface read model. Exposing it lets clients (e.g. the Terraform provider) read back the subnet an interface was provisioned onto, rather than only the parent network it resolved to.

## Scope

- Read model only; the request / import (`instance.interfaces`) schema is unchanged (that list does not carry the subnet id).
- No API behaviour change — this only makes the spec reflect the existing response.
- `redocly lint` passes.