### PR TITLE
Network Router NAT: config.action + request fields; router networkServer shape

### DIFF
--- a/components/examples/networkRouterNatCreate.json
+++ b/components/examples/networkRouterNatCreate.json
@@ -2,7 +2,7 @@
   "networkRouterNAT": {
     "name": "Name of NAT",
     "description": "Description of NAT",
-    "enabled": "on",
+    "enabled": true,
     "config": {
       "action": "SNAT",
       "service": "/infra/services/TELNET",

--- a/components/schemas/networkRouterNat.yaml
+++ b/components/schemas/networkRouterNat.yaml
@@ -5,6 +5,8 @@ properties:
     format: int32
   name:
     type: string
+  action:
+    type: string
   description:
     type: string
   enabled:

--- a/components/schemas/networkRouters.yaml
+++ b/components/schemas/networkRouters.yaml
@@ -70,9 +70,13 @@ type:
       items:
         type: object
 networkServer:
-  type:
-    - string
-    - 'null'
+  type: object
+  properties:
+    id:
+      type: integer
+      format: int64
+    name:
+      type: string
 zone:
   type: object
   properties:

--- a/components/schemas/networkRouters.yaml
+++ b/components/schemas/networkRouters.yaml
@@ -70,7 +70,9 @@ type:
       items:
         type: object
 networkServer:
-  type: object
+  type:
+    - object
+    - 'null'
   properties:
     id:
       type: integer

--- a/paths/api@networks@routers@id@nats.yaml
+++ b/paths/api@networks@routers@id@nats.yaml
@@ -47,9 +47,42 @@ post:
               description: For a full list of available NAT options, see natOptionTypes in the specific Network Router Type
               required:
                 - name
+                - config
               properties:
                 name:
+                  type: string
                   description: NAT name
+                description:
+                  type: string
+                  description: Description of the NAT rule.
+                enabled:
+                  type: boolean
+                  description: Whether the NAT rule is enabled.
+                sourceNetwork:
+                  type: string
+                  description: Source network for the NAT rule.
+                destinationNetwork:
+                  type: string
+                  description: Destination network for the NAT rule.
+                translatedNetwork:
+                  type: string
+                  description: Translated network for the NAT rule.
+                priority:
+                  type: integer
+                  format: int64
+                  description: Priority of the NAT rule.
+                protocol:
+                  type: string
+                  description: Protocol for the NAT rule.
+                config:
+                  type: object
+                  description: NAT config-context options (bound to the NAT's config map).
+                  required:
+                    - action
+                  properties:
+                    action:
+                      type: string
+                      description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
         examples: 
           Network Router NAT Request:
             value:

--- a/paths/api@networks@routers@id@nats@id.yaml
+++ b/paths/api@networks@routers@id@nats@id.yaml
@@ -46,7 +46,37 @@ put:
               description: For a full list of available NAT options, see natOptionTypes in the specific Network Router Type
               properties:
                 name:
+                  type: string
                   description: Sets name of NAT
+                description:
+                  type: string
+                  description: Description of the NAT rule.
+                enabled:
+                  type: boolean
+                  description: Whether the NAT rule is enabled.
+                sourceNetwork:
+                  type: string
+                  description: Source network for the NAT rule.
+                destinationNetwork:
+                  type: string
+                  description: Destination network for the NAT rule.
+                translatedNetwork:
+                  type: string
+                  description: Translated network for the NAT rule.
+                priority:
+                  type: integer
+                  format: int64
+                  description: Priority of the NAT rule.
+                protocol:
+                  type: string
+                  description: Protocol for the NAT rule.
+                config:
+                  type: object
+                  description: NAT config-context options (bound to the NAT's config map).
+                  properties:
+                    action:
+                      type: string
+                      description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
         examples: 
           Network Router NAT Request:
             value:


### PR DESCRIPTION
## Summary

Backs the `terraform-provider-hpe` NAT resource and network router data source (branch `fix-amv-tests`). Four related changes to the Network Router NAT API contract and the router response model.

### NAT create/update request — `paths/api@networks@routers@id@nats.yaml`, `…@nats@id.yaml`
- **Move `action` from the request root into `config.action`** — `required` on create, optional on update — to match what the Morpheus API actually expects (the appliance binds the NAT action via the config map, not a root field).
- Add the previously-missing NAT request properties: `description`, `enabled`, `sourceNetwork`, `destinationNetwork`, `translatedNetwork`, `priority`, `protocol`. Without these in the spec, the generated SDK had no way to send them and NAT provisioning silently dropped the fields.
- The create example (`components/examples/networkRouterNatCreate.json`) already nests `action` under `config`, so it stays consistent — no example change needed.

### NAT response model — `components/schemas/networkRouterNat.yaml`
- Add `action` (string) to the NAT response schema to document it as a NAT property.

### Router response model — `components/schemas/networkRouters.yaml`
- Type `networkServer` as an object `{id, name}` instead of `string | null`, so the GET router response deserialises correctly (needed to read tier-0 / tier-1 routers).

## Validation
- `bundled.yaml` is gitignored and bundled in CI, so no bundled artifact is committed here.
- Changes are standard structural additions consistent with existing sibling properties; expected to pass the `redocly lint` and `spectral lint` PR jobs.

## Context
Part of the `fix-amv-tests` networking effort. Once this lands, the official SDK regen should match the SDK the provider's `go.mod` will be bumped to.