### PR TITLE
Fix network transport zone and edge cluster read schemas

### DIFF
--- a/components/schemas/networkEdgeCluster.yaml
+++ b/components/schemas/networkEdgeCluster.yaml
@@ -1,6 +1,6 @@
 id:
   type: integer
-  format: int32
+  format: int64
 internalId:
   type: string
 visibility:
@@ -18,6 +18,8 @@ active:
 displayName:
   type: string
 name:
+  type: string
+description:
   type: string
 enabled:
   type: boolean
@@ -40,19 +42,19 @@ owner:
   properties:
     id:
       type: integer
-      format: int32
+      format: int64
 networkServer:
   type: object
   properties:
     id:
       type: integer
-      format: int32
+      format: int64
 zone:
   type: object
   properties:
     id:
       type: integer
-      format: int32
+      format: int64
 tenants:
   type: array
   items:
@@ -60,6 +62,6 @@ tenants:
     properties:
       id:
         type: integer
-        format: int32
+        format: int64
       name:
         type: string

--- a/components/schemas/networkTransportZone.yaml
+++ b/components/schemas/networkTransportZone.yaml
@@ -21,6 +21,8 @@ displayName:
   type: string
 name:
   type: string
+description:
+  type: string
 status:
   type: string
 enabled:

--- a/paths/api@networks@servers@id@edge-clusters.yaml
+++ b/paths/api@networks@servers@id@edge-clusters.yaml
@@ -22,6 +22,7 @@ get:
             - type: object
               properties:
                 networkEdgeClusters:
+                  type: array
                   items:
                     type: object
                     properties:

--- a/paths/api@networks@servers@id@scopes.yaml
+++ b/paths/api@networks@servers@id@scopes.yaml
@@ -21,6 +21,7 @@ get:
             - type: object
               properties:
                 networkScopes:
+                  type: array
                   items:
                     type: object
                     properties:


### PR DESCRIPTION
## Summary

Fixes three issues in the network transport zone (`/api/networks/servers/{serverId}/scopes`) and edge cluster (`/api/networks/servers/{serverId}/edge-clusters`) read schemas, found while building the corresponding Terraform data sources.

## Changes

1. **Add missing `description`** to the `networkTransportZone` and `networkEdgeCluster` read schemas. The API returns it (the `NetworkScope`/`NetworkEdgeCluster` domains define `String description`, and it is included in the API serialization views), but it was absent from the spec — so it never reached the SDK or the Terraform provider.

2. **Add `type: array`** to the `networkScopes` / `networkEdgeClusters` list-response properties. They had `items` but no `type: array`, so generators could not infer the element type and emitted an untyped array (`interface{}`), which forced a JSON-roundtrip workaround in the provider to read list results.

3. **Correct `networkEdgeCluster` id fields from `int32` to `int64`.** The `NetworkEdgeCluster` domain (and its `owner`/`networkServer`/`zone` references and tenants) use GORM `Long` ids. The `networkTransportZone` schema already uses `int64`; this aligns edge cluster with it. (`config.members` stays `int32` — it is a node count, not an id.)

## Validation

- `redocly lint openapi.yaml`: passes
- Bundled output verified: both list responses now resolve to `type: array` with typed items, and `description` propagates to both the GET-by-id and list responses.

## Follow-up

Requires an SDK regeneration to flow these into `hpe-morpheus-go-sdk`, after which the Terraform provider data sources (`hpe_morpheus_network_transport_zone`, `hpe_morpheus_network_edge_cluster`) will expose `description` and can drop the list-read JSON-roundtrip workaround.
