### PR TITLE
Fix snapshot read schema id fields from int32 to int64

### DIFF
--- a/components/schemas/snapshot.yaml
+++ b/components/schemas/snapshot.yaml
@@ -2,7 +2,7 @@ type: object
 properties:
   id:
     type: integer
-    format: int32
+    format: int64
   name:
     type: string
   description:
@@ -31,7 +31,7 @@ properties:
     properties:
       id:
         type: integer
-        format: int32
+        format: int64
       name:
         type: string
   datastore:
@@ -49,7 +49,7 @@ properties:
       properties:
         id:
           type: integer
-          format: int32
+          format: int64
         name:
           type: string
         type:
@@ -67,7 +67,7 @@ properties:
           properties:
             id:
               type: integer
-              format: int32
+              format: int64
         diskIndex:
           type: integer
   currentlyActive:


### PR DESCRIPTION
## Summary

Corrects the snapshot read schema (`components/schemas/snapshot.yaml`), which typed snapshot ids as `int32`. The Morpheus `Snapshot` domain has no `id` override, so it uses a GORM `Long` (`int64`); the `zone`, `snapshotFiles[]`, and `volume` references it embeds are likewise `Long`-id domain objects.

## Changes

Four `id` fields changed `int32` → `int64`:
- `id` (snapshot)
- `zone.id`
- `snapshotFiles[].id`
- `snapshotFiles[].volume.id`

`diskIndex` is left as `int32` (it is an index, not an id). The `snapshotId` and shared `id-path` path-parameter schemas were already `int64`, so SDK method signatures are unaffected.

`snapshot.yaml` is the shared response schema for both `getSnapshotInstance` (`GET /api/snapshots/{id}`) and the instance snapshots list (`GET /api/instances/{id}/snapshots`), so the fix flows to both generated SDK models.

## Validation

- `redocly lint openapi.yaml`: passes.

## Context

Found while building the `hpe_morpheus_instance_snapshot` Terraform resource, which had to cast `int64(*snap.Id)` to work around the mistyped id. Same fix class as the earlier `networkEdgeCluster` int64 correction. Requires an SDK regeneration to flow through; after that the provider can drop the cast.
