### PR TITLE
Remove snapshot name default; document server-side naming in description

### DIFF
--- a/components/schemas/instanceSnapshot.yaml
+++ b/components/schemas/instanceSnapshot.yaml
@@ -5,8 +5,7 @@ properties:
     properties:
       name:
         type: string
-        description: Optional name for the snapshot being created.
-        default: '{serverName}.{timestamp}'
+        description: Optional name for the snapshot being created. If omitted, the server generates one from the server name and a timestamp.
       description:
         type: string
         description: Optional description for the snapshot


### PR DESCRIPTION
## Summary

Removes the `default: '{serverName}.{timestamp}'` from the snapshot create request `name` field in `instanceSnapshot.yaml`, moving the behavior into the field description.

## Why

`{serverName}.{timestamp}` is a **server-side templated** name applied when `name` is omitted — not a literal client default. Expressing it as an OpenAPI `default` causes code generators to emit it onto the generated attribute; when a consumer needs `name` to be **required** (e.g. the Terraform `hpe_morpheus_instance_snapshot` resource, which must know the name up front to locate the async-created snapshot), a required-attribute-with-default is invalid and has to be patched out.

## Change

- `components/schemas/instanceSnapshot.yaml`: drop the `name` `default`; describe the server-side naming behavior in the `description` instead.

## Validation

- `redocly lint openapi.yaml`: passes.

Follow-up to the merged snapshot id int64 fix (#271).
