### PR TITLE
Type loadBalancerPool createdBy as an object (id, username)

### DIFF
--- a/components/schemas/loadBalancerPool.yaml
+++ b/components/schemas/loadBalancerPool.yaml
@@ -151,8 +151,14 @@ config:
   type: object
 createdBy:
   type:
-    - string
+    - object
     - 'null'
+  properties:
+    id:
+      type: integer
+      format: int64
+    username:
+      type: string
 dateCreated:
   type: string
   format: date-time


### PR DESCRIPTION
## What
Type the `createdBy` property in `components/schemas/loadBalancerPool.yaml` as a nullable object (`id`: int64, `username`: string) instead of a nullable string.

## Why
The Morpheus API returns `createdBy` as an object (e.g. `{"id": 42, "username": "jsmith"}`) for load balancer pools, not a string. The `string | null` typing caused the generated Go SDK to fail decoding every load balancer pool create/get/list/update response:

```
'loadBalancerPool.createdBy' expected type 'string', got unconvertible type 'map[string]interface {}'
```

This broke the Terraform provider's load balancer pool resource and data source. The change matches `loadBalancerMonitor.yaml`, which already types `createdBy` as an object.

## Scope
Single property type change. All load balancer pool responses (POST/GET/PUT/LIST) reference `loadBalancerPool.yaml`, so this one change fixes decoding for all of them.