### PR TITLE
Type the loadBalancerProfile config as per-serviceType anyOf variants

### DIFF
--- a/components/parameters/loadBalancerPoolId-path.yaml
+++ b/components/parameters/loadBalancerPoolId-path.yaml
@@ -3,5 +3,6 @@ in: path
 description: Load Balancer Pool ID
 required: true
 schema:
-  type: number
+  type: integer
+  format: int64
 example: 4

--- a/components/schemas/loadBalancerProfile.yaml
+++ b/components/schemas/loadBalancerProfile.yaml
@@ -80,7 +80,16 @@ persistenceExpiresIn:
 editable:
   type: boolean
 config:
-  type: object
+  description: Configuration object with parameters that vary by serviceType.
+  anyOf:
+    - $ref: loadBalancerProfileConfigHttp.yaml
+    - $ref: loadBalancerProfileConfigFastTcp.yaml
+    - $ref: loadBalancerProfileConfigFastUdp.yaml
+    - $ref: loadBalancerProfileConfigCookiePersistence.yaml
+    - $ref: loadBalancerProfileConfigSourceIpPersistence.yaml
+    - $ref: loadBalancerProfileConfigGenericPersistence.yaml
+    - $ref: loadBalancerProfileConfigClientSsl.yaml
+    - $ref: loadBalancerProfileConfigServerSsl.yaml
 createdBy:
   type:
     - string

--- a/components/schemas/loadBalancerProfileConfigClientSsl.yaml
+++ b/components/schemas/loadBalancerProfileConfigClientSsl.yaml
@@ -15,6 +15,7 @@ properties:
       - CUSTOM
   sessionCache:
     type: boolean
+    default: true
     description: Whether SSL session caching is enabled. Defaults to true.
   supportedSslCiphers:
     type: array
@@ -67,9 +68,11 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 300
     description: SSL session cache timeout in seconds. Defaults to 300. Range 1-86400.
   preferServerCipher:
     type: boolean
+    default: true
     description: Whether the server cipher order is preferred during SSL negotiation. Defaults to true.
   tags:
     type: array

--- a/components/schemas/loadBalancerProfileConfigClientSsl.yaml
+++ b/components/schemas/loadBalancerProfileConfigClientSsl.yaml
@@ -1,0 +1,78 @@
+title: Client SSL Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T client SSL profile (serviceType LBClientSslProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (ssl-profile).
+  sslSuite:
+    type: string
+    description: Predefined cipher suite. Use CUSTOM to specify supportedSslCiphers and supportedSslProtocols explicitly.
+    enum:
+      - BALANCED
+      - HIGH_COMPATIBILITY
+      - HIGH_SECURITY
+      - CUSTOM
+  sessionCache:
+    type: boolean
+    description: Whether SSL session caching is enabled. Defaults to true.
+  supportedSslCiphers:
+    type: array
+    description: Supported SSL ciphers. Required when sslSuite is CUSTOM.
+    items:
+      type: string
+      enum:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+        - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+        - TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+        - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+        - TLS_RSA_WITH_AES_256_CBC_SHA
+        - TLS_RSA_WITH_AES_128_CBC_SHA
+        - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+        - TLS_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_RSA_WITH_AES_256_CBC_SHA256
+        - TLS_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+        - TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+        - TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+  supportedSslProtocols:
+    type: array
+    description: Supported SSL/TLS protocols. Required when sslSuite is CUSTOM.
+    items:
+      type: string
+      enum:
+        - SSL_V2
+        - SSL_V3
+        - TLS_V1
+  sessionCacheTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: SSL session cache timeout in seconds. Defaults to 300. Range 1-86400.
+  preferServerCipher:
+    type: boolean
+    description: Whether the server cipher order is preferred during SSL negotiation. Defaults to true.
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigCookiePersistence.yaml
+++ b/components/schemas/loadBalancerProfileConfigCookiePersistence.yaml
@@ -1,0 +1,55 @@
+title: Cookie Persistence Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T cookie persistence profile (serviceType LBCookiePersistenceProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (persistence-profile).
+  sharePersistence:
+    type: boolean
+    description: Whether persistence is shared across virtual servers that use this profile.
+  cookieName:
+    type: string
+    description: Cookie name.
+  cookieFallback:
+    type: boolean
+    description: Whether to fall back to another pool member when the cookie-pointed member is down. Defaults to true.
+  cookieGarbling:
+    type: boolean
+    description: Whether the cookie value is encrypted (garbled). Defaults to true.
+  cookieMode:
+    type: string
+    description: Cookie persistence mode.
+    enum:
+      - INSERT
+      - PREFIX
+      - REWRITE
+  cookieDomain:
+    type: string
+    description: Cookie domain. Applies only when cookieMode is INSERT.
+  cookiePath:
+    type: string
+    description: Cookie path. Applies only when cookieMode is INSERT.
+  cookieType:
+    type: string
+    description: Cookie time type. Required when cookieMode is INSERT.
+    enum:
+      - LBSessionCookieTime
+      - LBPersistenceCookieTime
+  maxIdleTime:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Maximum idle time in milliseconds the cookie persists. Applies only when cookieMode is INSERT.
+  maxCookieAge:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Maximum age in milliseconds the cookie persists. Applies only when cookieMode is INSERT.
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigCookiePersistence.yaml
+++ b/components/schemas/loadBalancerProfileConfigCookiePersistence.yaml
@@ -13,9 +13,11 @@ properties:
     description: Cookie name.
   cookieFallback:
     type: boolean
+    default: true
     description: Whether to fall back to another pool member when the cookie-pointed member is down. Defaults to true.
   cookieGarbling:
     type: boolean
+    default: true
     description: Whether the cookie value is encrypted (garbled). Defaults to true.
   cookieMode:
     type: string

--- a/components/schemas/loadBalancerProfileConfigFastTcp.yaml
+++ b/components/schemas/loadBalancerProfileConfigFastTcp.yaml
@@ -10,6 +10,7 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 1800
     description: Idle timeout in seconds before an inactive connection is closed. Defaults to 1800.
   haFlowMirroring:
     type: boolean
@@ -19,6 +20,7 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 8
     description: Timeout in seconds before a closed connection is removed. Defaults to 8. Range 1-60.
   tags:
     type: array

--- a/components/schemas/loadBalancerProfileConfigFastTcp.yaml
+++ b/components/schemas/loadBalancerProfileConfigFastTcp.yaml
@@ -1,0 +1,27 @@
+title: Fast TCP Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T Fast TCP application profile (serviceType LBFastTcpProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (application-profile).
+  fastTcpIdleTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Idle timeout in seconds before an inactive connection is closed. Defaults to 1800.
+  haFlowMirroring:
+    type: boolean
+    description: Whether all flows to the active member are mirrored to the standby member.
+  connectionCloseTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Timeout in seconds before a closed connection is removed. Defaults to 8. Range 1-60.
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigFastUdp.yaml
+++ b/components/schemas/loadBalancerProfileConfigFastUdp.yaml
@@ -1,0 +1,21 @@
+title: Fast UDP Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T Fast UDP application profile (serviceType LBFastUdpProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (application-profile).
+  fastUdpIdleTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Idle timeout in seconds before an inactive flow is closed. Defaults to 300.
+  haFlowMirroring:
+    type: boolean
+    description: Whether all flows to the active member are mirrored to the standby member.
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigFastUdp.yaml
+++ b/components/schemas/loadBalancerProfileConfigFastUdp.yaml
@@ -10,6 +10,7 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 300
     description: Idle timeout in seconds before an inactive flow is closed. Defaults to 300.
   haFlowMirroring:
     type: boolean

--- a/components/schemas/loadBalancerProfileConfigGenericPersistence.yaml
+++ b/components/schemas/loadBalancerProfileConfigGenericPersistence.yaml
@@ -1,0 +1,24 @@
+title: Generic Persistence Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T generic persistence profile (serviceType LBGenericPersistenceProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (persistence-profile).
+  sharePersistence:
+    type: boolean
+    description: Whether persistence is shared across virtual servers that use this profile.
+  haPersistenceMirroring:
+    type: boolean
+    description: Whether persistence entries are synchronized to the standby node for high availability.
+  persistenceEntryTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Persistence entry timeout in seconds. Defaults to 300.
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigGenericPersistence.yaml
+++ b/components/schemas/loadBalancerProfileConfigGenericPersistence.yaml
@@ -16,6 +16,7 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 300
     description: Persistence entry timeout in seconds. Defaults to 300.
   tags:
     type: array

--- a/components/schemas/loadBalancerProfileConfigHttp.yaml
+++ b/components/schemas/loadBalancerProfileConfigHttp.yaml
@@ -1,0 +1,60 @@
+title: HTTP Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T HTTP application profile (serviceType LBHttpProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (application-profile).
+  httpIdleTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Idle timeout in seconds before an inactive connection is closed. Defaults to 15. Range 1-5400.
+  requestHeaderSize:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Maximum request header size in bytes. Defaults to 1024. Range 1-65536.
+  responseHeaderSize:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Maximum response header size in bytes. Defaults to 4096. Range 1-65536.
+  httpsRedirect:
+    type: string
+    description: HTTP to HTTPS redirection. Stored as "on" or "off".
+    enum:
+      - 'on'
+      - 'off'
+  redirectAddress:
+    type: string
+    description: Redirect address. Required when httpsRedirect is "off".
+  xForwardedFor:
+    type: string
+    description: X-Forwarded-For header handling.
+    enum:
+      - INSERT
+      - REPLACE
+  requestBodySize:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Maximum request body size in bytes. Range 1-2147483647.
+  responseTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Response timeout in seconds. Defaults to 60.
+  ntlmAuthentication:
+    type: boolean
+    description: Whether NTLM authentication is enabled.
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigHttp.yaml
+++ b/components/schemas/loadBalancerProfileConfigHttp.yaml
@@ -10,18 +10,21 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 15
     description: Idle timeout in seconds before an inactive connection is closed. Defaults to 15. Range 1-5400.
   requestHeaderSize:
     type:
       - integer
       - 'null'
     format: int64
+    default: 1024
     description: Maximum request header size in bytes. Defaults to 1024. Range 1-65536.
   responseHeaderSize:
     type:
       - integer
       - 'null'
     format: int64
+    default: 4096
     description: Maximum response header size in bytes. Defaults to 4096. Range 1-65536.
   httpsRedirect:
     type: string
@@ -49,6 +52,7 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 60
     description: Response timeout in seconds. Defaults to 60.
   ntlmAuthentication:
     type: boolean

--- a/components/schemas/loadBalancerProfileConfigServerSsl.yaml
+++ b/components/schemas/loadBalancerProfileConfigServerSsl.yaml
@@ -15,6 +15,7 @@ properties:
       - CUSTOM
   sessionCache:
     type: boolean
+    default: true
     description: Whether SSL session caching is enabled. Defaults to true.
   supportedSslCiphers:
     type: array

--- a/components/schemas/loadBalancerProfileConfigServerSsl.yaml
+++ b/components/schemas/loadBalancerProfileConfigServerSsl.yaml
@@ -1,0 +1,69 @@
+title: Server SSL Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T server SSL profile (serviceType LBServerSslProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (ssl-profile).
+  sslSuite:
+    type: string
+    description: Predefined cipher suite. Use CUSTOM to specify supportedSslCiphers and supportedSslProtocols explicitly.
+    enum:
+      - BALANCED
+      - HIGH_COMPATIBILITY
+      - HIGH_SECURITY
+      - CUSTOM
+  sessionCache:
+    type: boolean
+    description: Whether SSL session caching is enabled. Defaults to true.
+  supportedSslCiphers:
+    type: array
+    description: Supported SSL ciphers. Required when sslSuite is CUSTOM.
+    items:
+      type: string
+      enum:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+        - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+        - TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+        - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+        - TLS_RSA_WITH_AES_256_CBC_SHA
+        - TLS_RSA_WITH_AES_128_CBC_SHA
+        - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+        - TLS_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_RSA_WITH_AES_256_CBC_SHA256
+        - TLS_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+        - TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+        - TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+        - TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+  supportedSslProtocols:
+    type: array
+    description: Supported SSL/TLS protocols. Required when sslSuite is CUSTOM.
+    items:
+      type: string
+      enum:
+        - SSL_V2
+        - SSL_V3
+        - TLS_V1
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigSourceIpPersistence.yaml
+++ b/components/schemas/loadBalancerProfileConfigSourceIpPersistence.yaml
@@ -1,0 +1,27 @@
+title: Source IP Persistence Load Balancer Profile Config
+type: object
+description: Configuration object for the NSX-T source IP persistence profile (serviceType LBSourceIpPersistenceProfile).
+properties:
+  profileType:
+    type: string
+    description: Profile category. Automatically set from serviceType (persistence-profile).
+  sharePersistence:
+    type: boolean
+    description: Whether persistence is shared across virtual servers that use this profile.
+  purgeEntries:
+    type: boolean
+    description: Whether the oldest persistence entries are purged when the table is full. Defaults to true.
+  haPersistenceMirroring:
+    type: boolean
+    description: Whether persistence entries are synchronized to the standby node for high availability.
+  persistenceEntryTimeout:
+    type:
+      - integer
+      - 'null'
+    format: int64
+    description: Persistence entry timeout in seconds. Defaults to 300.
+  tags:
+    type: array
+    description: NSX-T tags applied to the profile.
+    items:
+      $ref: loadBalancerProfileConfigTag.yaml

--- a/components/schemas/loadBalancerProfileConfigSourceIpPersistence.yaml
+++ b/components/schemas/loadBalancerProfileConfigSourceIpPersistence.yaml
@@ -10,6 +10,7 @@ properties:
     description: Whether persistence is shared across virtual servers that use this profile.
   purgeEntries:
     type: boolean
+    default: true
     description: Whether the oldest persistence entries are purged when the table is full. Defaults to true.
   haPersistenceMirroring:
     type: boolean
@@ -19,6 +20,7 @@ properties:
       - integer
       - 'null'
     format: int64
+    default: 300
     description: Persistence entry timeout in seconds. Defaults to 300.
   tags:
     type: array

--- a/components/schemas/loadBalancerProfileConfigTag.yaml
+++ b/components/schemas/loadBalancerProfileConfigTag.yaml
@@ -1,0 +1,10 @@
+title: Load Balancer Profile Tag
+type: object
+description: NSX-T tag applied to the load balancer profile.
+properties:
+  name:
+    type: string
+    description: Tag name.
+  value:
+    type: string
+    description: Tag scope/value.

--- a/components/schemas/loadBalancerProfileCreate.yaml
+++ b/components/schemas/loadBalancerProfileCreate.yaml
@@ -7,6 +7,14 @@ description:
 serviceType: 
   type: string
   description: Service Type
-config: 
-  type: object
-  description: Configuration object with parameters that vary by type.
+config:
+  description: Configuration object with parameters that vary by serviceType.
+  anyOf:
+    - $ref: loadBalancerProfileConfigHttp.yaml
+    - $ref: loadBalancerProfileConfigFastTcp.yaml
+    - $ref: loadBalancerProfileConfigFastUdp.yaml
+    - $ref: loadBalancerProfileConfigCookiePersistence.yaml
+    - $ref: loadBalancerProfileConfigSourceIpPersistence.yaml
+    - $ref: loadBalancerProfileConfigGenericPersistence.yaml
+    - $ref: loadBalancerProfileConfigClientSsl.yaml
+    - $ref: loadBalancerProfileConfigServerSsl.yaml


### PR DESCRIPTION
Types the `loadBalancerProfile` config (create + read) as 8 per-serviceType `anyOf` variants for NSX-T, replacing the free-form `object`. Supports MORPH-7620 (Terraform `hpe_morpheus_load_balancer_profile`).

### Variants
New `components/schemas/loadBalancerProfileConfig*.yaml`, referenced from both `loadBalancerProfileCreate.yaml` and `loadBalancerProfile.yaml`:

- **Application:** HTTP, FastTcp, FastUdp
- **Persistence:** Cookie, SourceIp, Generic
- **SSL:** Client, Server
- **Shared:** Tag item (`loadBalancerProfileConfigTag.yaml`)

Each variant carries typed fields, enums and constraints, including `httpsRedirect` (`on`/`off`), `cookieType` (`LBSessionCookieTime`/`LBPersistenceCookieTime`), `cookieMode`, `sslSuite`, and the verbose SSL cipher (31) / protocol lists.

### Also
`loadBalancerPoolId` path parameter `number` → `integer/int64`, matching the `NetworkLoadBalancerPool` Long id and the existing `loadBalancerId` parameter (one param `$ref`'d by all load-balancer-pool node paths).

### Validation
- `redocly bundle openapi.yaml` resolves all `$ref`s cleanly (exit 0).
- `redocly lint` introduces no new findings: the 2 remaining errors are pre-existing in `networkRouter.yaml` / `networkRouters.yaml` (untouched here); warnings unchanged at the existing baseline.

### Downstream
On merge: regenerate `hpe-morpheus-go-sdk` so the profile config is exposed as a typed `anyOf` wrapper, then the Terraform resource/data source build proceeds.
