### PR TITLE
Add userGroup and storageProfile to instance create/clone and read schemas

### DIFF
--- a/components/examples/instances.json
+++ b/components/examples/instances.json
@@ -66,7 +66,7 @@
               "resourcePoolId": 4080,
               "poolProviderType": null,
               "userGroup": {
-                  "id": ""
+                  "id": null
               },
               "expireDays": "2",
               "shutdownDays": "1",

--- a/components/schemas/instance.yaml
+++ b/components/schemas/instance.yaml
@@ -188,8 +188,9 @@ properties:
         properties:
           id:
             type:
-              - string
+              - integer
               - 'null'
+            format: int64
       expireDays:
         type: string
       shutdownDays:
@@ -1055,6 +1056,11 @@ properties:
                     type:
                       - string
                       - 'null'
+                  storageProfile:
+                    type:
+                      - string
+                      - 'null'
+                    description: Storage Profile Code for the volume storage profile assignment. eg. `"kvm-cache-none"` or `"kvm-cache-directsync"`. Use `/api/provision-types?code=kvm` to see the available `storageProfiles` for HVM and KVM.
                   storageServer:
                     type: object
                     title: Instance Container Server Volume Storage Server

--- a/components/schemas/instanceClone.yaml
+++ b/components/schemas/instanceClone.yaml
@@ -31,6 +31,15 @@ properties:
         format: int64
         description: The id of the service plan (the pre-configured memory and storage option) for the clone.
         example: 75
+  userGroup:
+    type: object
+    description: Optional user group reference for the clone. Provide the user group id.
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: The user group id.
+        example: 1
   volumes:
     type: array
     description: |

--- a/components/schemas/instanceCreate.yaml
+++ b/components/schemas/instanceCreate.yaml
@@ -81,6 +81,15 @@ properties:
             format: int64
             description: The Network Domain ID to provision the instance into.
             example: 3
+      userGroup:
+        type: object
+        description: Optional user group reference. Provide the user group id; the group's owner can be created as a user on the instance when create_user is enabled.
+        properties:
+          id:
+            type: integer
+            format: int64
+            description: The user group id.
+            example: 1
   zoneId:
     type: integer
     format: int64


### PR DESCRIPTION
Supports MORPH-13001 — wiring `user_group` and `storage_profile` into the typed config of the Terraform `instance` and `instance_clone` resources.

## Changes

- **userGroup** (cloud-agnostic): added a top-level `userGroup { id }` object to `instanceCreate.yaml` (under the `instance` key) and `instanceClone.yaml` (top-level), matching how the API binds `instance.userGroup`. The provider exposes this as a single top-level `user_group` Int64 and wraps/unwraps the `{id}` object.
- **userGroup read fix**: corrected the instance read `config.userGroup.id` from `string` to `integer`/`int64`. The `UserGroup` id is a Long, so the previous string typing was a spec inaccuracy.
- **storageProfile**: added to the instance read container-server volume schema so the storage profile round-trips on read and import. The create and clone request volumes already carry it.

## Notes

`user_group` is provision-time only — verified in the API source that neither the instance update (`PUT`) nor resize re-applies it — so the provider models it as `requires_replace`. This PR is the schema side only; the SDK regen and provider wiring follow once this merges.

## Validation

- `redocly bundle` succeeds.
- `redocly lint` introduces no new findings (the 2 pre-existing errors are in `networkRouter`).
