### PR TITLE
Updates required to add visibility and tenants

### DIFF
--- a/components/schemas/clusterUpdate.yaml
+++ b/components/schemas/clusterUpdate.yaml
@@ -47,6 +47,9 @@ properties:
           type: integer
           format: int64
           description: Integration ID. Only certain integration types may be associated to a cluster.
+  visibility:
+    type: string
+    description: Visibility setting
   config:
     type: object
     description: Configuration object with parameters that vary by `type`. Only the specified config properties will be updated, other existing config properties will be left unchanged.

--- a/components/schemas/networkGroupsCreate.yaml
+++ b/components/schemas/networkGroupsCreate.yaml
@@ -13,3 +13,15 @@ properties:
     type: array
     items: 
       type: object
+  visibility:
+    $ref: visibility.yaml
+  tenants:
+    type: array
+    description: Array of tenant account ids that are allowed access
+    nullable: true
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64


### PR DESCRIPTION
Updates required to spec to add visibility and tenants to the network groups and clusters.