### PR TITLE
Add typed storage volume config (Alletra MP BMaaS) and provisionType

### DIFF
--- a/components/schemas/storageVolumeConfigAlletraMPBmaas.yaml
+++ b/components/schemas/storageVolumeConfigAlletraMPBmaas.yaml
@@ -1,0 +1,51 @@
+type: object
+title: Alletra MP BMaaS Volume Configuration
+description: >
+  Configuration for creating an HPE Alletra Storage MP block storage volume on a Bare Metal
+  (BMaaS) storage server. Property names are the Alletra MP plugin's native config keys.
+properties:
+  hpe_storage_datastore:
+    type: integer
+    format: int64
+    description: ID of the Alletra MP BMaaS data store (pool) in which to create the volume.
+  hpe_storage_volume_shared:
+    type: string
+    description: >
+      Whether the volume is shared (multi-attach). When 'off' the volume may be exported to a
+      single compute server; when 'on' it may be exported to one or more instances.
+    enum:
+      - "on"
+      - "off"
+  hpe_storage_compute_server:
+    type: string
+    description: >
+      Compute server to export a non-shared volume to, in the form "[id: <computeServerId>]".
+      Mutually exclusive with hpe_storage_instances.
+  hpe_storage_instances:
+    type: array
+    items:
+      type: string
+    description: >
+      Instances to export a shared volume to, each in the form "[id: <instanceId>]".
+      Mutually exclusive with hpe_storage_compute_server.
+  hpe_storage_remotecopytarget_id:
+    type: string
+    description: >
+      Remote copy (replication) target ID. Required for replicated LUN volume types
+      (Peer Persistence: Active or Classic).
+  hpe_storage_existing_volume_set:
+    type: string
+    description: Whether to add the volume to an existing, exported volume set rather than creating a new one.
+    enum:
+      - "on"
+      - "off"
+  hpe_storage_volumeset_id:
+    type: string
+    description: ID of an existing volume set to add the volume to (when using an existing volume set).
+  hpe_storage_volume_set_name:
+    type: string
+    description: >
+      Base name for a new volume set (a unique suffix is always appended). Used when not using an
+      existing volume set.
+required:
+  - hpe_storage_datastore

--- a/components/schemas/storageVolumeConfigGeneric.yaml
+++ b/components/schemas/storageVolumeConfigGeneric.yaml
@@ -1,0 +1,3 @@
+title: Generic Storage Volume Configuration
+description: Generic configuration options for the storage volume, varies based on the storage volume type.
+type: object

--- a/paths/api@storage-volumes.yaml
+++ b/paths/api@storage-volumes.yaml
@@ -66,8 +66,13 @@ post:
                   type: string
                   description: Storage Type Code or ID
                 config:
-                  type: object
                   description: Configuration object with parameters that vary by `type`.
+                  anyOf:
+                    - $ref: ../components/schemas/storageVolumeConfigGeneric.yaml
+                    - $ref: ../components/schemas/storageVolumeConfigAlletraMPBmaas.yaml
+                provisionType:
+                  type: string
+                  description: Provision type for storage volume types that support it (for example 3Par - FULL, TPVV, SNP, PEER, TDVV).
                 storageServer:
                   type: object
                   required:


### PR DESCRIPTION
## Summary
Adds a typed `config` `anyOf` (generic + Alletra MP BMaaS variant) and a top-level `provisionType` to the storage volume create schema, mirroring the shipped datastore `config_alletramp_hvm` pattern.

This is the foundation for a typed `config_alletramp_bmaas` block on the Terraform provider's `hpe_morpheus_storage_volume` resource, plus top-level `provision_type` / `storage_group_id` support.

## Changes
- **New** `components/schemas/storageVolumeConfigAlletraMPBmaas.yaml` — Alletra MP Bare Metal (BMaaS) volume config keys: datastore (required), shared, compute server / instances export targets, replication target, existing-volume-set + volume-set id/name. Property names are the plugin's native config keys; `compute_server`/`instances` document the `[id: N]` reference format.
- **New** `components/schemas/storageVolumeConfigGeneric.yaml` — generic fallback variant for other storage volume types.
- **Edit** `paths/api@storage-volumes.yaml` — `storageVolume.config` becomes `anyOf: [generic, alletra-mp-bmaas]`; add `storageVolume.provisionType` (used by 3Par volume types: FULL, TPVV, SNP, PEER, TDVV).

## Validation
- `redocly lint openapi.yaml` → valid, exit 0
- `spectral lint -F error` on the dereferenced bundle → 0 errors (pre-existing `oas3-unused-component` warnings only)
- No existing attributes removed.