### PR TITLE
Fix server labels type to array of strings

### DIFF
--- a/components/schemas/server.yaml
+++ b/components/schemas/server.yaml
@@ -499,7 +499,7 @@ properties:
       - array
       - 'null'
     items:
-      type: object
+      type: string
   tags:
     type:
       - array


### PR DESCRIPTION
## Summary

The `server` schema declared `labels` as an array of objects, but the API returns an array of strings (e.g. `["terraform"]`). SDK clients that decode the servers response into typed models fail with a decoding error on `labels[*]`.

## Change
- `components/schemas/server.yaml`: `labels.items.type` `object` -> `string`, matching the other schemas (e.g. `instance.yaml`). `tags` is unchanged.

## Impact
Fixes typed decoding of `GET /api/servers` and the related host endpoints (get host, baremetal create, resize, assign-tenant). Verified by regenerating the Go SDK and successfully listing/deleting unmanaged servers via the provider sweeper.