### PR TITLE
fix(storage-volumes): storageServer optional, storageGroup object

### DIFF
--- a/components/schemas/storageVolume.yaml
+++ b/components/schemas/storageVolume.yaml
@@ -130,9 +130,8 @@ properties:
   datastoreOption:
     type: string
   storageGroup:
-    type:
-      - string
-      - 'null'
+    type: object
+    description: The storage group the volume belongs to (id and name).
   namespace:
     type:
       - string
@@ -160,6 +159,10 @@ properties:
       - string
       - 'null'
   fiberWwn:
+    type:
+      - string
+      - 'null'
+  wwn:
     type:
       - string
       - 'null'

--- a/components/schemas/storageVolume.yaml
+++ b/components/schemas/storageVolume.yaml
@@ -130,7 +130,9 @@ properties:
   datastoreOption:
     type: string
   storageGroup:
-    type: object
+    type:
+      - object
+      - 'null'
     description: The storage group the volume belongs to (id and name).
   namespace:
     type:

--- a/paths/api@storage-volumes.yaml
+++ b/paths/api@storage-volumes.yaml
@@ -57,7 +57,6 @@ post:
               required:
                 - name
                 - type
-                - storageServer
               properties:
                 name: 
                   type: string


### PR DESCRIPTION
Validated against morpheus-ui (StorageVolumesController.save, StorageVolumeMarshaller, StorageVolume domain). Remove storageServer from the addStorageVolumes required list: a volume can be created via storageGroup (e.g. 3PAR) or storageServer (e.g. Alletra MP), so it is not always required (this also stops sending storageServer.id=0 when omitted). storageGroup in the read schema is an object (serialized via StorageGroupModel), not a string, so clients can read back the group id. Add wwn (String wwn on the StorageVolume domain) to the read schema.
