### PR TITLE
resourcePermissions/tenants/visibility for 1.4 resources

### DIFF
--- a/components/schemas/clusterAffinityGroupCreate.yaml
+++ b/components/schemas/clusterAffinityGroupCreate.yaml
@@ -29,15 +29,6 @@ properties:
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml
-  tenants:
-    type: array
-    description: Array of tenant account ids that are allowed access
-    items:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
   resourcePermissions:
     type: object
     description: Resource Permissions for controlling Group Access

--- a/components/schemas/clusterAffinityGroupUpdate.yaml
+++ b/components/schemas/clusterAffinityGroupUpdate.yaml
@@ -26,15 +26,6 @@ properties:
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml
-  tenants:
-    type: array
-    description: Array of tenant account ids that are allowed access
-    items:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
   resourcePermissions:
     type: object
     description: Resource Permissions for controlling Group Access

--- a/components/schemas/clusterNamespace.yaml
+++ b/components/schemas/clusterNamespace.yaml
@@ -16,6 +16,19 @@ properties:
   permissions: 
     type: object
     properties: 
+      tenantPermissions:
+        type: object
+        properties:
+          accounts:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
       resourcePermissions: 
         type: object
         properties: 

--- a/components/schemas/clusterNamespaceCreate.yaml
+++ b/components/schemas/clusterNamespaceCreate.yaml
@@ -12,35 +12,53 @@ properties:
     type: boolean
     description: Namespace active
     default: false
-  resourcePermissions: 
+  visibility:
+    type: string
+    description: Visibility level (public or private)
+  permissions:
     type: object
-    description: Map for namespace group and service plan permissions.
-    properties: 
-      all: 
-        type: boolean
-        description: Pass true to allow access to all groups
-      sites: 
-        type: array
-        description: Array of groups that are allowed access
-        items: 
-          type: object
-          properties: 
-            id: 
-              type: integer
-              format: int64
-            default: 
-              type: boolean
-      allPlans: 
-        type: boolean
-        description: Pass true to allow access to all plans
-      plans: 
-        type: array
-        description: Array of plans that are allowed access
-        items: 
-          type: object
-          properties: 
-            id: 
-              type: integer
-              format: int64
-            default: 
-              type: boolean
+    properties:
+      tenantPermissions:
+        type: object
+        properties:
+          accounts:
+            type: array
+            description: Array of tenant account IDs
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  format: int64
+      resourcePermissions: 
+        type: object
+        description: Map for namespace group and service plan permissions.
+        properties: 
+          all: 
+            type: boolean
+            description: Pass true to allow access to all groups
+          sites: 
+            type: array
+            description: Array of groups that are allowed access
+            items: 
+              type: object
+              properties: 
+                id: 
+                  type: integer
+                  format: int64
+                default: 
+                  type: boolean
+          allPlans: 
+            type: boolean
+            description: Pass true to allow access to all plans
+          plans: 
+            type: array
+            description: Array of plans that are allowed access
+            items: 
+              type: object
+              properties: 
+                id: 
+                  type: integer
+                  format: int64
+                default: 
+                  type: boolean

--- a/components/schemas/clusterNamespaceCreate.yaml
+++ b/components/schemas/clusterNamespaceCreate.yaml
@@ -25,11 +25,8 @@ properties:
             type: array
             description: Array of tenant account IDs
             items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                  format: int64
+              type: integer
+              format: int64
       resourcePermissions: 
         type: object
         description: Map for namespace group and service plan permissions.

--- a/components/schemas/clusterNamespaceUpdate.yaml
+++ b/components/schemas/clusterNamespaceUpdate.yaml
@@ -23,11 +23,8 @@ properties:
             type: array
             description: Array of tenant account IDs
             items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                  format: int64
+              type: integer
+              format: int64
       resourcePermissions: 
         type: object
         description: Map for namespace group and service plan permissions.

--- a/components/schemas/clusterNamespaceUpdate.yaml
+++ b/components/schemas/clusterNamespaceUpdate.yaml
@@ -10,9 +10,24 @@ properties:
     type: boolean
     description: Namespace active
     default: false
+  visibility:
+    type: string
+    description: Visibility level (public or private)
   permissions:
     type: object
     properties:
+      tenantPermissions:
+        type: object
+        properties:
+          accounts:
+            type: array
+            description: Array of tenant account IDs
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  format: int64
       resourcePermissions: 
         type: object
         description: Map for namespace group and service plan permissions.

--- a/components/schemas/networkFirewallRuleGroup.yaml
+++ b/components/schemas/networkFirewallRuleGroup.yaml
@@ -96,3 +96,15 @@ rules:
         type: array
         items:
           type: object
+visibility:
+  type: string
+tenants:
+  type: array
+  items:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string

--- a/components/schemas/networkFirewallRuleGroupCreate.yaml
+++ b/components/schemas/networkFirewallRuleGroupCreate.yaml
@@ -20,3 +20,15 @@ properties:
     description: Use SecurityPolicy
   groupLayer: 
     type: string
+  visibility:
+    type: string
+    description: Visibility level (public or private)
+  tenants:
+    type: array
+    description: Array of tenant accounts
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64

--- a/components/schemas/networkGroup.yaml
+++ b/components/schemas/networkGroup.yaml
@@ -29,7 +29,9 @@ tenants:
       name: 
         type: string
 resourcePermission:
-  type: object
+  type:
+    - object
+    - 'null'
   properties:
     all:
       type: boolean
@@ -46,7 +48,9 @@ resourcePermission:
           default:
             type: boolean
     allPlans:
-      type: boolean
+      type:
+        - boolean
+        - 'null'
     plans:
       type: array
       items:

--- a/components/schemas/networkGroup.yaml
+++ b/components/schemas/networkGroup.yaml
@@ -28,3 +28,34 @@ tenants:
         format: int64
       name: 
         type: string
+resourcePermission:
+  type: object
+  properties:
+    all:
+      type: boolean
+    sites:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+          name:
+            type: string
+          default:
+            type: boolean
+    allPlans:
+      type: boolean
+    plans:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: integer
+            format: int64
+          name:
+            type: string
+          default:
+            type: boolean

--- a/components/schemas/networkGroupsCreate.yaml
+++ b/components/schemas/networkGroupsCreate.yaml
@@ -4,6 +4,12 @@ properties:
     type: string
   description: 
     type: string
+  visibility:
+    type: string
+    description: Visibility level (public or private)
+  active:
+    type: boolean
+    description: Network group active flag
   networks: 
     type: array
     items: 

--- a/components/schemas/provisioningLicense.yaml
+++ b/components/schemas/provisioningLicense.yaml
@@ -35,6 +35,12 @@ properties:
     type: array
     items: 
       type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
   virtualImages: 
     type: array
     items: 

--- a/components/schemas/resourcePermissions.yaml
+++ b/components/schemas/resourcePermissions.yaml
@@ -1,11 +1,17 @@
 type: object
 properties:
   defaultStore:
-    type: boolean
+    type:
+      - boolean
+      - 'null'
   defaultTarget:
-    type: boolean
+    type:
+      - boolean
+      - 'null'
   canManage:
-    type: boolean
+    type:
+      - boolean
+      - 'null'
   all:
     type: boolean
   account:
@@ -29,7 +35,9 @@ properties:
         default:
           type: boolean
   allPlans:
-    type: boolean
+    type:
+      - boolean
+      - 'null'
   plans:
     type:
       - array

--- a/paths/api@clusters@id@affinity-groups.yaml
+++ b/paths/api@clusters@id@affinity-groups.yaml
@@ -52,6 +52,18 @@ post:
           properties:
             affinityGroup:
               $ref: ../components/schemas/clusterAffinityGroupCreate.yaml
+            tenantPermissions:
+              type: object
+              properties:
+                accounts:
+                  type: array
+                  description: Array of tenant account IDs
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
         examples:
           Create Affinity Group Request:
             value:

--- a/paths/api@clusters@id@affinity-groups.yaml
+++ b/paths/api@clusters@id@affinity-groups.yaml
@@ -59,11 +59,8 @@ post:
                   type: array
                   description: Array of tenant account IDs
                   items:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                        format: int64
+                    type: integer
+                    format: int64
         examples:
           Create Affinity Group Request:
             value:

--- a/paths/api@clusters@id@affinity-groups@id.yaml
+++ b/paths/api@clusters@id@affinity-groups@id.yaml
@@ -42,6 +42,18 @@ put:
           properties: 
             affinityGroup:
               $ref: ../components/schemas/clusterAffinityGroupUpdate.yaml
+            tenantPermissions:
+              type: object
+              properties:
+                accounts:
+                  type: array
+                  description: Array of tenant account IDs
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
         examples:
           Update Affinity Group Request:
             value:

--- a/paths/api@clusters@id@affinity-groups@id.yaml
+++ b/paths/api@clusters@id@affinity-groups@id.yaml
@@ -49,11 +49,8 @@ put:
                   type: array
                   description: Array of tenant account IDs
                   items:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                        format: int64
+                    type: integer
+                    format: int64
         examples:
           Update Affinity Group Request:
             value:

--- a/paths/api@networks@groups.yaml
+++ b/paths/api@networks@groups.yaml
@@ -50,11 +50,8 @@ post:
                   type: array
                   description: Array of tenant account IDs
                   items:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                        format: int64
+                    type: integer
+                    format: int64
             resourcePermissions:
               type: object
               properties:

--- a/paths/api@networks@groups.yaml
+++ b/paths/api@networks@groups.yaml
@@ -70,6 +70,18 @@ post:
                       id:
                         type: integer
                         format: int64
+                allPlans:
+                  type: boolean
+                  description: Pass true to allow access to all service plans
+                plans:
+                  type: array
+                  description: Array of service plan IDs that are allowed access
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
         examples: 
           Successful Request:
             value: 

--- a/paths/api@networks@groups.yaml
+++ b/paths/api@networks@groups.yaml
@@ -43,6 +43,33 @@ post:
           properties: 
             networkGroup:
               $ref: ../components/schemas/networkGroupsCreate.yaml
+            tenantPermissions:
+              type: object
+              properties:
+                accounts:
+                  type: array
+                  description: Array of tenant account IDs
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
+            resourcePermissions:
+              type: object
+              properties:
+                all:
+                  type: boolean
+                  description: Pass true to allow access to all groups
+                sites:
+                  type: array
+                  description: Array of groups that are allowed access
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
         examples: 
           Successful Request:
             value: 

--- a/paths/api@networks@groups@id.yaml
+++ b/paths/api@networks@groups@id.yaml
@@ -44,6 +44,33 @@ put:
           properties: 
             networkGroup:
               $ref: ../components/schemas/networkGroupsCreate.yaml
+            tenantPermissions:
+              type: object
+              properties:
+                accounts:
+                  type: array
+                  description: Array of tenant account IDs
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
+            resourcePermissions:
+              type: object
+              properties:
+                all:
+                  type: boolean
+                  description: Pass true to allow access to all groups
+                sites:
+                  type: array
+                  description: Array of groups that are allowed access
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
         examples: 
           Network Group Request:
             value:

--- a/paths/api@networks@groups@id.yaml
+++ b/paths/api@networks@groups@id.yaml
@@ -71,6 +71,18 @@ put:
                       id:
                         type: integer
                         format: int64
+                allPlans:
+                  type: boolean
+                  description: Pass true to allow access to all service plans
+                plans:
+                  type: array
+                  description: Array of service plan IDs that are allowed access
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
         examples: 
           Network Group Request:
             value:

--- a/paths/api@networks@groups@id.yaml
+++ b/paths/api@networks@groups@id.yaml
@@ -51,11 +51,8 @@ put:
                   type: array
                   description: Array of tenant account IDs
                   items:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                        format: int64
+                    type: integer
+                    format: int64
             resourcePermissions:
               type: object
               properties:

--- a/paths/api@networks@servers@id@firewall-rule-groups@id.yaml
+++ b/paths/api@networks@servers@id@firewall-rule-groups@id.yaml
@@ -63,6 +63,18 @@ put:
                     - 'null'
                   format: int64
                   description: Network firewall rule group priority
+                visibility:
+                  type: string
+                  description: Visibility level (public or private)
+                tenants:
+                  type: array
+                  description: Array of tenant accounts
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
         examples: 
           Network Firewall Rule Group:
             value:

--- a/paths/api@power-schedules.yaml
+++ b/paths/api@power-schedules.yaml
@@ -131,6 +131,9 @@ post:
                   type: string
                   description: Sunday Off time of the day in 24-hour format
                   default: "24:00"
+                visibility:
+                  type: string
+                  description: Visibility level (public or private)
   responses:
     '200':
       description: Successful Request

--- a/paths/api@power-schedules@id.yaml
+++ b/paths/api@power-schedules@id.yaml
@@ -155,6 +155,9 @@ put:
                   type: string
                   description: Sunday Off time of the day in 24-hour format
                   default: 24:00
+                visibility:
+                  type: string
+                  description: Visibility level (public or private)
   responses:
     '200':
       description: Successful Request


### PR DESCRIPTION
Adding
- visibility, tenants to clusterNamepsace (resourcePermissions already added)
- visibility, tenants to networkFirewallRuleGroup
- resourcePermissions to networkGroup (also missing active in create)
- object properties to provisioningLicense tenant object
- nullables to resourcePermissions (after going through source code)
- tenants and resourcePermission to network groups

(will return for backupJobs)