### PR TITLE
Add maxStorage to storage volume create/update request schemas

### DIFF
--- a/paths/api@storage-volumes.yaml
+++ b/paths/api@storage-volumes.yaml
@@ -64,6 +64,10 @@ post:
                 type:
                   type: string
                   description: Storage Type Code or ID
+                maxStorage:
+                  type: integer
+                  format: int64
+                  description: The size of the storage volume in bytes.
                 config:
                   description: Configuration object with parameters that vary by `type`.
                   anyOf:

--- a/paths/api@storage-volumes@id.yaml
+++ b/paths/api@storage-volumes@id.yaml
@@ -51,6 +51,10 @@ put:
                 type:
                   type: string
                   description: Storage Type Code or ID
+                maxStorage:
+                  type: integer
+                  format: int64
+                  description: The size of the storage volume in bytes.
                 config:
                   type: object
                   description: Configuration object with parameters that vary by `type`.


### PR DESCRIPTION
Adds the `maxStorage` property (volume size in bytes, `integer`/`int64`) to the request payloads of:

- `POST /api/storage-volumes` (`addStorageVolumes`)
- `PUT /api/storage-volumes/{id}` (`updateStorageVolumes`)

It was already present in the `storageVolume` response schema but missing from the request schemas. The HPE Terraform provider relies on this field to set the volume size (currently sent via `additionalProperties`, pending SDK regeneration).

Verified with `redocly bundle`.