### PR TITLE
Add datastore BMaaS config, cluster datastoreType code, and data-store-types endpoint

### DIFF
--- a/components/schemas/clusterDatastoreCreate.yaml
+++ b/components/schemas/clusterDatastoreCreate.yaml
@@ -8,6 +8,11 @@ properties:
       id:
         type: integer
         format: int64
+      code:
+        type: string
+        description: >
+          The code of the datastore type. If provided, it takes precedence
+          over id.
   storageServer:
     type: object
     properties:

--- a/components/schemas/datastoreTypes.yaml
+++ b/components/schemas/datastoreTypes.yaml
@@ -1,0 +1,51 @@
+type: object
+properties:
+  id:
+    type: integer
+    format: int64
+  code:
+    type: string
+  name:
+    type: string
+  externalType:
+    type: string
+  externalSubType:
+    type: string
+  diskType:
+    type: string
+  creatable:
+    type: boolean
+  removable:
+    type: boolean
+  editable:
+    type: boolean
+  localStorage:
+    type: boolean
+  isPlugin:
+    type: boolean
+  pluginManagedVolumeRefresh:
+    type: boolean
+  isEmbedded:
+    type: boolean
+  imageTargetCapable:
+    type: boolean
+  heartbeatTargetCapable:
+    type: boolean
+  checkpointTargetCapable:
+    type: boolean
+  supportsVmSecureMetadataCapable:
+    type: boolean
+  discoverable:
+    type: boolean
+  hasMaintenanceMode:
+    type: boolean
+  storageServerType:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+  optionTypes:
+    type: array
+    items:
+      $ref: optionType.yaml

--- a/components/schemas/storageDatastoreConfigAlletraMPBmaas.yaml
+++ b/components/schemas/storageDatastoreConfigAlletraMPBmaas.yaml
@@ -1,0 +1,12 @@
+type: object
+title: Alletra MP BMAAS Datastore Configuration
+description: HPE Alletra Storage MP Bare Metal (BMaaS) datastore configuration
+properties:
+  protocolType:
+    type: string
+    description: Storage protocol to use, can be 'iSCSI' or 'FC'
+    enum:
+      - iSCSI
+      - FC
+required:
+  - protocolType

--- a/components/schemas/storageDatastoreCreate.yaml
+++ b/components/schemas/storageDatastoreCreate.yaml
@@ -13,6 +13,7 @@ properties:
       - $ref: clusterDatastoreConfigGFS2.yaml
       - $ref: storageDatastoreConfigGeneric.yaml
       - $ref: storageDatastoreConfigAlletraMPHVM.yaml
+      - $ref: storageDatastoreConfigAlletraMPBmaas.yaml
   refType:
     type: string
     enum:
@@ -25,6 +26,16 @@ properties:
     description: The ID of the resource this datastore is associated with, e.g. ComputeZone, ComputeServerGroup
   storageServer:
     type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+  zonePool:
+    type: object
+    description: >
+      The resource pool (CloudPool) the datastore is created in. Required for
+      HPE Alletra Storage MP Bare Metal (BMaaS) datastores; ignored by other
+      datastore types.
     properties:
       id:
         type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -402,6 +402,8 @@ paths:
     $ref: paths/api@cypher.yaml
   /api/cypher/{cypherPath}:
     $ref: paths/api@cypher@id.yaml
+  /api/data-store-types:
+    $ref: paths/api@data-store-types.yaml
   /api/data-stores:
     $ref: paths/api@datastores.yaml
   /api/data-stores/{id}:

--- a/paths/api@data-store-types.yaml
+++ b/paths/api@data-store-types.yaml
@@ -1,0 +1,25 @@
+get:
+  summary: Get All Datastore Types
+  description: >
+    Fetch a list of available datastore types, including the configuration
+    option types for each. This endpoint returns all datastore types with no
+    pagination.
+  operationId: listDatastoreTypes
+  tags:
+    - Datastores
+  responses:
+    '200':
+      description: Successful Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              datastoreTypes:
+                type: array
+                items:
+                  $ref: ../components/schemas/datastoreTypes.yaml
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
Spec changes for the HPE Alletra MP Bare Metal (BMaaS) datastore work (MORPH-13500).

## Changes

- **BMaaS datastore config** — add `storageDatastoreConfigAlletraMPBmaas` (`protocolType`, iSCSI/FC) to the `storageDatastoreCreate` config `anyOf`, plus a top-level `zonePool{id}` for the resource pool that BMaaS datastores require (the storage plugin binds `datastore.zonePool` and rejects the create without it).
- **Cluster datastoreType by code** — accept `datastoreType.code` (in addition to `id`) on the cluster datastore create endpoint (`clusterDatastoreCreate`), matching the API, which has resolved the type by code since 8.0.1.
- **`GET /api/data-store-types`** — new `listDatastoreTypes` endpoint returning all datastore types with their configuration option types (new `datastoreTypes` schema, reusing `optionType`).

Consumed by the terraform-provider-hpe `hpe_morpheus_datastore` resource (`config_alletramp_bmaas`) and a forthcoming `hpe_morpheus_datastore_types` data source.