### PR TITLE
Add BMaaS instance provision config variant

### DIFF
--- a/components/schemas/instanceCreate.yaml
+++ b/components/schemas/instanceCreate.yaml
@@ -148,6 +148,7 @@ properties:
       - $ref: instancesConfigAWS.yaml
       - $ref: instancesConfigGeneric.yaml
       - $ref: instancesConfigHVM.yaml
+      - $ref: instancesConfigBMaaS.yaml
   labels:
     type: array
     description: Array of strings (keywords).

--- a/components/schemas/instancesConfigBMaaS.yaml
+++ b/components/schemas/instancesConfigBMaaS.yaml
@@ -1,0 +1,39 @@
+title: BMaaS Instance Configuration
+type: object
+description: Configuration options for HPE bare metal (BMaaS) instances.
+required:
+  - imageId
+properties:
+  imageId:
+    type: integer
+    format: int64
+    description: The id of the ISO virtual image to boot the bare metal instance from.
+  resourcePoolId:
+    type: string
+    description: id of the resource pool to provision into, can be prefixed with `pool-`. A resource pool group can be specified instead by prefixing its ID with `poolGroup-`.
+  createUser:
+    type:
+      - boolean
+      - 'null'
+    description: Whether to create a user when provisioning the instance.
+    default: false
+  noAgent:
+    type:
+      - boolean
+      - 'null'
+    description: Skipping Agent installation will result in a lack of logging and guest operating system statistics. Automation scripts may also be adversely affected.
+    default: false
+  enforceRaidBootVolume:
+    type: boolean
+    description: When enabled, provisioning fails if a RAID boot volume cannot be created. When disabled, provisioning falls back to a single disk if RAID1 is unavailable.
+    default: true
+  selectedHosts:
+    type: array
+    description: The bare metal host(s) to provision this workload on. Each item wraps the host id in a `value` field (the baremetal plugin reads each selected host as `host.value`).
+    items:
+      type: object
+      properties:
+        value:
+          type: integer
+          format: int64
+          description: The id of a bare metal host to provision this workload on.


### PR DESCRIPTION
Adds `instancesConfigBMaaS` to the instance create `config` anyOf, documenting the HPE bare metal (BMaaS) instance provision config.

## Fields
- `imageId` (int64, **required**) — the ISO virtual image to boot from
- `resourcePoolId` (string) — `pool-` / `poolGroup-` prefixable
- `createUser` (bool, default `false`)
- `noAgent` (bool, default `false`)
- `enforceRaidBootVolume` (bool, default `true`)
- `selectedHosts` (array of `{ value: int64 }`) — the `host.value` shape the baremetal plugin reads

This is the config that terraform-provider-hpe`s `hpe_morpheus_instance` `config_bmaas` block (PR #1235) currently sends through the generic config map. Landing this lets the provider use a typed, spec-backed config variant instead.

Mirrors the existing `instancesConfigHVM` variant style; bundle validated with redocly.