### PR TITLE
Define id/name on storageVolume storageGroup and storageServer

### DIFF
--- a/components/schemas/storageVolume.yaml
+++ b/components/schemas/storageVolume.yaml
@@ -133,13 +133,26 @@ properties:
     type:
       - object
       - 'null'
-    description: The storage group the volume belongs to (id and name).
+    description: The storage group the volume belongs to.
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
   namespace:
     type:
       - string
       - 'null'
   storageServer:
     type: object
+    description: The storage server the volume is provisioned on.
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
   source:
     type: string
   uniqueId:


### PR DESCRIPTION
## Summary

The `storageVolume` **response** schema declared `storageGroup` and `storageServer` as propertyless objects. Downstream code generators could only model them as untyped maps, and the generated Terraform schema produced an empty nested block that silently dropped the data.

This adds the `id` and `name` properties to both objects — matching the already-typed request-body models and what the API actually returns (a storage group / storage server with id + name) — so generated clients get typed structs.

## Notes

- Scoped to the `storageVolume` response schema; affects every endpoint that references it (storage volumes, cluster volumes/volumeclaims, host and baremetal host volumes, host resize).
- The corresponding regenerated Go SDK has already landed with its Terraform provider consumers (which vendor the SDK in-tree), so the generated client and the code using it stay in lockstep. This PR is the spec side of that change — see HPE/terraform-provider-hpe#1247.
