### PR TITLE
loadBalancerProfileConfigTag: use NSX-T {scope,tag} keys

### DIFF
--- a/components/schemas/loadBalancerProfileConfigTag.yaml
+++ b/components/schemas/loadBalancerProfileConfigTag.yaml
@@ -2,9 +2,9 @@ title: Load Balancer Profile Tag
 type: object
 description: NSX-T tag applied to the load balancer profile.
 properties:
-  name:
+  scope:
     type: string
-    description: Tag name.
-  value:
+    description: Tag scope. Maps to the Terraform tag "value".
+  tag:
     type: string
-    description: Tag scope/value.
+    description: Tag name. Maps to the Terraform tag "name".


### PR DESCRIPTION
## Summary

Changes the `loadBalancerProfileConfigTag` schema from `{name, value}` to `{scope, tag}` to match what NSX-T actually expects for load balancer profile config tags.

## Why

The load_balancer_profile create sends config tags straight through to NSX-T. NSX-T rejects the property named `name` with *"Json de-serialization error: property name is unrecognized"*, because NSX-T tags use `scope`/`tag` (see `NsxtLoadBalancerService` tag mapping, which maps morpheus `name`→NSX-T `tag` and `value`→NSX-T `scope`). This schema is referenced only by the eight NSX-T profile config variants, so the change is NSX-T-scoped.

## Mapping

| Terraform (unchanged) | Spec / SDK (this PR) | NSX-T |
|---|---|---|
| `name` | `tag` | tag |
| `value` | `scope` | scope |

The provider keeps the Terraform-facing `name`/`value` attributes and remaps to `tag`/`scope` when talking to the API.

## Companion / ordering

Paired with terraform-provider-hpe#1259, which carries the regenerated SDK tag models and the provider remap. **Merge the provider PR first** (its in-tree SDK is generated from the local spec and is self-contained); merge this spec PR afterward.

Draft pending validation on an NSX-T environment.