### PR TITLE
Network router firewall rule: add create fields and rule group tenants/visibility

### DIFF
--- a/components/schemas/networkRouterFirewallRuleCreate.yaml
+++ b/components/schemas/networkRouterFirewallRuleCreate.yaml
@@ -14,3 +14,34 @@ properties:
     type: integer
     format: int64
     description: Priority for rule
+  policy:
+    type: string
+    description: Rule policy / action. Valid values depend on the network router type (see ruleOptionTypes).
+  direction:
+    type: string
+    description: Traffic direction the rule applies to (for example incoming, outgoing, bidirectional).
+  sourceType:
+    type: string
+    description: Source match type (for example any, cidr, group, instance).
+  destinationType:
+    type: string
+    description: Destination match type (for example any, cidr, group, instance).
+  protocol:
+    type: string
+    description: Network protocol the rule matches (for example tcp, udp, icmp, any).
+  portRange:
+    type: string
+    description: Port or port range the rule matches (for example 443 or 8080-8090).
+  application:
+    type: string
+    description: Application the rule matches, when supported by the network router type.
+  description:
+    type: string
+    description: Description of the firewall rule.
+  config:
+    type: object
+    description: Network-router-type-specific rule configuration.
+    properties:
+      parentId:
+        type: string
+        description: External id of the parent firewall rule group (required by NSX-T).

--- a/components/schemas/networkRouterFirewallRuleGroup.yaml
+++ b/components/schemas/networkRouterFirewallRuleGroup.yaml
@@ -28,6 +28,20 @@ priority:
   format: int64
 groupLayer:
   type: string
+visibility:
+  type: string
+  description: Visibility of the rule group, either 'public' or 'private'.
+tenants:
+  type: array
+  description: Tenants that have been granted access to the rule group.
+  items:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
 rules:
   type: array
   items:

--- a/paths/api@networks@routers@id@firewall-rule-groups.yaml
+++ b/paths/api@networks@routers@id@firewall-rule-groups.yaml
@@ -16,6 +16,7 @@ get:
             type: object
             properties:
               ruleGroups:
+                type: array
                 items:
                   type: object
                   properties:

--- a/paths/api@networks@routers@id@firewall-rule-groups@id.yaml
+++ b/paths/api@networks@routers@id@firewall-rule-groups@id.yaml
@@ -17,6 +17,7 @@ get:
             type: object
             properties:
               ruleGroup:
+                type: object
                 properties:
                   $ref: ../components/schemas/networkRouterFirewallRuleGroup.yaml
           examples:


### PR DESCRIPTION
## Summary

Fills gaps in the network router firewall rule and rule group schemas — validated against the Grails implementation and required by the Terraform provider.

### Firewall rule create/update (`networkRouterFirewallRuleCreate`, also backs PUT)

The schema defined only `name`, `enabled`, `priority`, but the API accepts more. Added: `policy`, `direction`, `sourceType`, `destinationType`, `protocol`, `portRange`, `application`, `description`, and `config.parentId`. These bind server-side via the firewall rule create/update bind list; `application` is a plain string (distinct from `applications[]` / `applicationType`); `parentId` is nested under `config` (`group-<id>`).

### Firewall rule group (`networkRouterFirewallRuleGroup`)

Added `tenants` (array of `{id, name}`) and `visibility` (string, `private`/`public`) — both returned only to master-tenant callers.

### firewall-rule-groups paths

Typed the `ruleGroups` list response as an `array` and the single `ruleGroup` response as an `object` (they were missing `type:`, which prevented the schemas from generating cleanly).

## Notes

Validated against the Morpheus UI (the firewall rule create/update bind list and the GSON response views). `description` is accepted on write but is **not** returned by the GET rule response, so it is intentionally not added to the response schema.

The regenerated Go SDK for these models has already been delivered to its Terraform provider consumer (HPE/terraform-provider-hpe#1256), so the generated client and the code using it stay in lockstep. This PR is the spec side of that change.
