### PR TITLE
Align container script schemas with the API

### DIFF
--- a/components/schemas/script.yaml
+++ b/components/schemas/script.yaml
@@ -52,3 +52,9 @@ properties:
     type: boolean
   failOnError:
     type: boolean
+  dateCreated:
+    type: string
+    format: date-time
+  lastUpdated:
+    type: string
+    format: date-time

--- a/components/schemas/scriptCreate.yaml
+++ b/components/schemas/scriptCreate.yaml
@@ -5,6 +5,7 @@ properties:
   name:
     type: string
     description: Script name
+    maxLength: 255
   labels:
     type:
       - array
@@ -22,6 +23,17 @@ properties:
   scriptPhase:
     type: string
     description: Phase for the script, provision, start, etc.
+    enum:
+      - start
+      - stop
+      - preProvision
+      - provision
+      - postProvision
+      - preDeploy
+      - deploy
+      - reconfigure
+      - scaleDown
+      - teardown
   scriptType:
     type: string
     description: Type for the script

--- a/components/schemas/scriptUpdate.yaml
+++ b/components/schemas/scriptUpdate.yaml
@@ -3,6 +3,7 @@ properties:
   name:
     type: string
     description: Script name
+    maxLength: 255
   labels:
     type:
       - array
@@ -20,6 +21,17 @@ properties:
   scriptPhase:
     type: string
     description: Phase for the script, provision, start, etc.
+    enum:
+      - start
+      - stop
+      - preProvision
+      - provision
+      - postProvision
+      - preDeploy
+      - deploy
+      - reconfigure
+      - scaleDown
+      - teardown
   scriptType:
     type: string
     description: Type for the script


### PR DESCRIPTION
## Summary

Align the container script schemas with the actual Morpheus API behaviour:

- **`name`** — add `maxLength: 255` on `scriptCreate` and `scriptUpdate`. The `ContainerScript` domain declares no explicit constraint, so the column defaults to VARCHAR(255) and an over-long name currently returns a 500.
- **`scriptPhase`** — add an `enum` on `scriptCreate` and `scriptUpdate` matching `OptionSourceConstants.containerPhasesList` (`start`, `stop`, `preProvision`, `provision`, `postProvision`, `preDeploy`, `deploy`, `reconfigure`, `scaleDown`, `teardown`).
- **`script` response model** — add `dateCreated` and `lastUpdated`, which `serializeContainerScript` returns but the spec omitted (response-only, `format: date-time`).

## Source of truth
`ContainerScript.groovy` (constraints), `ContainerScriptsController.serializeContainerScript` (response fields), `OptionSourceConstants.containerPhasesList` (phase values).

## Coordination
Supports the Terraform provider container_script work in HPE/terraform-provider-hpe#1257. The provider's bundled SDK and generated schema were regenerated from these changes, and the provider's `name`/`script_phase` validators are now generated from these spec constraints — so this must merge in lockstep with that provider PR.

Validated with `redocly bundle` + `redocly lint` (both green).
