### PR TITLE
Network router NAT: add firewall and service config fields

### DIFF
--- a/paths/api@networks@routers@id@nats.yaml
+++ b/paths/api@networks@routers@id@nats.yaml
@@ -82,7 +82,19 @@ post:
                   properties:
                     action:
                       type: string
-                      description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
+                      description: >-
+                        The NAT action (config-context). NSX-T values: SNAT, DNAT,
+                        NO_SNAT, NO_DNAT, REFLEXIVE.
+                    firewall:
+                      type: string
+                      description: >-
+                        Firewall match mode for the NAT rule (config-context). NSX-T
+                        values: MATCH_EXTERNAL_ADDRESS, MATCH_INTERNAL_ADDRESS, BYPASS.
+                    service:
+                      type: string
+                      description: >-
+                        Service the NAT rule applies to (config-context). For NSX-T this
+                        is a service path, for example /infra/services/HTTP.
         examples: 
           Network Router NAT Request:
             value:

--- a/paths/api@networks@routers@id@nats@id.yaml
+++ b/paths/api@networks@routers@id@nats@id.yaml
@@ -76,7 +76,19 @@ put:
                   properties:
                     action:
                       type: string
-                      description: The NAT action (e.g. SNAT, DNAT, REFLEXIVE).
+                      description: >-
+                        The NAT action (config-context). NSX-T values: SNAT, DNAT,
+                        NO_SNAT, NO_DNAT, REFLEXIVE.
+                    firewall:
+                      type: string
+                      description: >-
+                        Firewall match mode for the NAT rule (config-context). NSX-T
+                        values: MATCH_EXTERNAL_ADDRESS, MATCH_INTERNAL_ADDRESS, BYPASS.
+                    service:
+                      type: string
+                      description: >-
+                        Service the NAT rule applies to (config-context). For NSX-T this
+                        is a service path, for example /infra/services/HTTP.
         examples: 
           Network Router NAT Request:
             value:


### PR DESCRIPTION
## Summary

The network router NAT create/update `config` block only defined `action`, but the API also accepts `firewall` and `service` as config-context option types on the router type. This adds them.

### Changes
- `nats.yaml` (create) and `nats@id.yaml` (update): add `firewall` and `service` (optional strings) under `config`.
- Expanded the `action` / `firewall` descriptions with the full NSX-T value sets.

### Field details (validated against the Grails implementation)
- `firewall` — config-context; NSX-T values `MATCH_EXTERNAL_ADDRESS` / `MATCH_INTERNAL_ADDRESS` / `BYPASS` (maps to the NSX-T `firewall_match` property).
- `service` — config-context; optional; an NSX-T service path string (for example `/infra/services/HTTP`).
- `action` — already present; the full NSX-T set is `SNAT`, `DNAT`, `NO_SNAT`, `NO_DNAT`, `REFLEXIVE`.

## Notes

The Terraform provider already vendors an SDK that models these config fields; regenerating the SDK from this spec change produces an **identical** NAT config model, so the generated client and its consumer stay in lockstep. This PR formalises the fields in the spec so a future regeneration cannot drop them.
