### PR TITLE
Type container script account as an object to match the API

### DIFF
--- a/components/examples/script.json
+++ b/components/examples/script.json
@@ -2,7 +2,10 @@
   "containerScript": {
     "id": 10,
     "code": "cassandra-2.1-vm-start",
-    "account": null,
+    "account": {
+      "id": 1,
+      "name": "Morpheus QA"
+    },
     "name": "cassandra start",
     "category": null,
     "sortOrder": 1,

--- a/components/examples/scripts.json
+++ b/components/examples/scripts.json
@@ -3,7 +3,10 @@
     {
       "id": 10,
       "code": "cassandra-2.1-vm-start",
-      "account": null,
+      "account": {
+        "id": 1,
+        "name": "Morpheus QA"
+      },
       "name": "cassandra start",
       "labels": [],
       "category": null,
@@ -22,7 +25,10 @@
     {
       "id": 9,
       "code": "cassandra-2.1-vm-stop",
-      "account": null,
+      "account": {
+        "id": 1,
+        "name": "Morpheus QA"
+      },
       "name": "cassandra stop",
       "category": null,
       "sortOrder": 1,

--- a/components/schemas/script.yaml
+++ b/components/schemas/script.yaml
@@ -6,9 +6,13 @@ properties:
   code:
     type: string
   account:
-    type:
-      - string
-      - 'null'
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
   name:
     type: string
   labels:


### PR DESCRIPTION
## Summary

`GET /api/library/container-scripts/{id}` (and the list endpoint) return `account` as an
object (`{id, name}`), but `components/schemas/script.yaml` typed `account` as a nullable
string. This breaks generated Go SDK decoding of container script read responses
(`account expected type 'string', got map[string]interface {}`).

Model `account` as an `{id, name}` object, matching the sibling `bootScript.yaml` schema
and the actual API response.

## Related

Provider PR (regenerated in-tree SDK + consuming `container_script` data source):
HPE/terraform-provider-hpe#1266

Per the in-tree SDK workflow, the provider PR carries the regenerated SDK and is
self-contained; it merges **first**, then this spec PR.
