### PR TITLE
Fix cluster layout virtualImage type; add subnet-types/{id}

### DIFF
--- a/components/schemas/clusterLayout.yaml
+++ b/components/schemas/clusterLayout.yaml
@@ -141,8 +141,14 @@ properties:
                   type: string
             virtualImage:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             category:
               type: string
             config:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1148,6 +1148,8 @@ paths:
     $ref: paths/api@accounts@id@user-sources.yaml
   /api/subnet-types:
     $ref: paths/api@subnet-types.yaml
+  /api/subnet-types/{id}:
+    $ref: paths/api@subnet-types@id.yaml
   /api/subnets:
     $ref: paths/api@subnets.yaml
   /api/subnets/{id}:

--- a/paths/api@subnet-types@id.yaml
+++ b/paths/api@subnet-types@id.yaml
@@ -1,0 +1,27 @@
+get:
+  summary: Get a Specific Subnet Type
+  description: |
+    This endpoint retrieves a specific network subnet type and its configuration options.
+  operationId: getSubnetType
+  tags:
+    - Networks
+  parameters:
+    - $ref: ../components/parameters/id-path.yaml
+  responses:
+    '200':
+      description: Successful Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              subnetType:
+                $ref: ../components/schemas/subnet-type.yaml
+          examples:
+            Response:
+              value:
+                $ref: ../components/examples/subnet-types.json
+    '4XX':
+      $ref: ../components/responses/4xx.yaml
+    '5XX':
+      $ref: ../components/responses/5xx.yaml


### PR DESCRIPTION
Companion spec changes for the terraform-provider-hpe acceptance-test fixes.

- **clusterLayout.yaml**: `computeServers[].containerType.virtualImage` returns an object `{id, name}`, not a string. Retyped so the generated Go SDK decodes the cluster layout response instead of failing with a type-conversion error (fixes the provider's `hpe_morpheus_cluster_layout` data source).
- **subnet-types/{id}**: add `GET /api/subnet-types/{id}` (`getSubnetType`). The endpoint exists in the API and is referenced by the provider's `subnet_type` data source read config; its absence broke the provider codegen pipeline.

Merge order: the provider PR is self-contained (SDK is vendored in-tree and generated from the local spec) and merges first; this spec PR is the source-of-truth follow-up.