### PR TITLE
MORPH-12636: Add tenantCopies to the role show response

### DIFF
--- a/components/schemas/role.yaml
+++ b/components/schemas/role.yaml
@@ -35,6 +35,29 @@ properties:
           - 'null'
       diverged:
         type: boolean
+      tenantCopies:
+        type: array
+        description: >-
+          The per-tenant copies of a multitenant master role, each identifying a
+          subtenant and the id of the role copy propagated into it. Populated
+          only for multitenant=true master roles on Morpheus 9.0.2 and later;
+          empty or absent otherwise.
+        items:
+          type: object
+          properties:
+            tenantId:
+              type: integer
+              format: int64
+              description: The id of the subtenant (account) the copy belongs to.
+            roleId:
+              type: integer
+              format: int64
+              description: The id of the propagated per-tenant role copy.
+            diverged:
+              type: boolean
+              description: >-
+                Whether the subtenant has modified (diverged) its copy, which
+                stops further propagation of changes from the master role.
       ownerId:
         type: integer
         format: int64


### PR DESCRIPTION
## What

Adds a `tenantCopies` collection to the role show response (`GET /api/roles/{id}`). For a `multitenant` master role, each entry exposes the subtenant (`tenantId`), the propagated copy role id (`roleId`), and a `diverged` flag. It is empty or absent for non-multitenant roles.

## Why

When a role is `multitenant`, Morpheus propagates a per-tenant copy into each subtenant with a new id, but there was no API path from the master role to those copies. `tenantCopies` provides that mapping so consumers (the HPE Terraform Provider, scripts, integrations) can resolve a master role to its subtenant copy ids (MORPH-12636).

## Related PRs

- Companion provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1278