### PR TITLE
Make vdiGateway gatewayUrl optional on create

### DIFF
--- a/paths/api@vdi-gateways.yaml
+++ b/paths/api@vdi-gateways.yaml
@@ -55,7 +55,6 @@ post:
               - type: object
                 required:
                   - name
-                  - gatewayUrl
                 properties:
                   name: 
                     type: string


### PR DESCRIPTION
## Summary

Removes `gatewayUrl` from the `required` list of the `addVDIGateways` (`POST /api/vdi-gateways`) request body. The API's VDI gateway domain model marks `gatewayUrl` nullable and the create service enforces no requirement on it, so the spec should not mark it required.

## Related PRs

- Companion Terraform provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1289

Fixes MORPH-12185.