### PR TITLE
Make storageBucket config and bucketName optional

### DIFF
--- a/paths/api@storage-buckets.yaml
+++ b/paths/api@storage-buckets.yaml
@@ -54,8 +54,6 @@ post:
               required:
                 - name
                 - providerType
-                - bucketName
-                - config
               properties:
                 name: 
                   type: string


### PR DESCRIPTION
## Summary

Make the `addStorageBuckets` request's `config` and `bucketName` optional.

`config` is a `oneOf`; the Go SDK generator emits it as a value-type field that
is always serialized, and its zero-value `MarshalJSON` returns `(nil, nil)`,
crashing storage-bucket creation with "unexpected end of JSON input" whenever a
bucket is created without an explicit config (e.g. an S3 bucket whose
credentials are supplied separately). Both fields are conditional per their own
descriptions (`bucketName` "only applies to Amazon/Azure/CIFS/NFSv3/Openstack
Swift/Rackspace CDN"), so mark them optional. The generated Go fields then become
pointers with `omitempty` and are omitted when unset.

## Related PRs

- Terraform provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1290
