### PR TITLE
ci: pin openapi-generator-cli to v7.12.0

### DIFF
--- a/.github/workflows/openapi-generator.yml
+++ b/.github/workflows/openapi-generator.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           args: bundle --dereferenced openapi.yaml -o bundle.yaml
       - name: OpenAPI Generator Validate
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.12.0
         with:
           args: validate -i bundle.yaml
         env:
@@ -20,7 +20,7 @@ jobs:
           mkdir client-go
           cp .openapi-generator/.openapi-generator-ignore client-go
       - name: OpenAPI Generator Generate
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.12.0
         with:
           args: generate -i bundle.yaml -g go -t .openapi-generator/go/templates -o client-go
         env:


### PR DESCRIPTION
## Summary

The `openapi-generator-go` workflow pulled the generator via the floating `docker://openapitools/openapi-generator-cli:latest` tag. `:latest` currently resolves to an **unreleased nightly (`7.24.0-SNAPSHOT`)** whose Go composed-schema (`anyOf`) template emits invalid Go for several config models, breaking the **Go Build** step even on PRs that don't touch those schemas.

This pins both generator steps (validate + generate) to **`v7.12.0`** — the version used by the Terraform provider codegen pipeline — for reproducible generation. `redocly/cli` is already pinned (`2.10.0`); only the generator was floating.

## Root cause (confirmed by reproduction)

The failure was **not** caused by any spec change. It is caused entirely by `:latest` drifting to a broken nightly build:

- `docker run --rm openapitools/openapi-generator-cli:latest version` → **`7.24.0-SNAPSHOT`**. Its image digest matches no stable `v7.x.0` release tag, and it was **republished 2026-07-15 08:07**, ~2 hours before the failing CI run (10:15).
- tf-dev's own SDK-gen checks last passed on 2026-07-10; identical generation began failing on 2026-07-15 with no relevant spec change — matching the `:latest` image bump.

Reproduction matrix (bundling + templates held to CI's, varying only the generator):

| redocly | generator | templates | Result |
|---|---|---|---|
| 1.34.3 | 7.23.0 (latest **stable**) | provider pipeline | ✅ valid Go |
| 2.10.0 (CI's) | 7.23.0 (latest **stable**) | CI's (`.openapi-generator/go/templates`) | ✅ valid Go |
| 2.10.0 (CI's) | `:latest` = 7.24.0-SNAPSHOT | CI's | ❌ `syntax error: unexpected * in struct type` |

So no stable release reproduces the bug (7.12.0 ✅, 7.23.0 ✅); only the `7.24.0-SNAPSHOT` nightly does. The affected files were `anyOf` config wrappers (e.g. `network_router_bgp_neighbor`, `cloud_resource_pools`) where the nightly's composed-schema template produced an empty pointer type (`Field *` with no type name).

Pinning to a stable release tag removes the moving-target nightly entirely, so a future snapshot cannot silently break unrelated PRs again.

## Follow-up

After merge, re-run the failing `openapi-generator-go` check on open PRs (e.g. the VDI gateway spec PR) — no changes to those PRs are required.