### PR TITLE
dev-9.0: Pin OpenAPI Generator CI to 7.12.0

### DIFF
--- a/.github/workflows/openapi-generator.yml
+++ b/.github/workflows/openapi-generator.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           args: bundle --dereferenced openapi.yaml -o bundle.yaml
       - name: OpenAPI Generator Validate
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.12.0
         with:
           args: validate -i bundle.yaml
         env:
@@ -20,7 +20,7 @@ jobs:
           mkdir client-go
           cp .openapi-generator/.openapi-generator-ignore client-go
       - name: OpenAPI Generator Generate
-        uses: docker://openapitools/openapi-generator-cli:latest
+        uses: docker://openapitools/openapi-generator-cli:v7.12.0
         with:
           args: generate -i bundle.yaml -g go -t .openapi-generator/go/templates -o client-go
         env:


### PR DESCRIPTION
In `tf-dev`, we noticed a breakage this morning as a result of the `openapi-generator-cli` Docker image being pinned to `latest`:

https://github.com/HewlettPackard/morpheus-openapi/pull/307

It pulled a nightly release which contained some breaking changes to SDK generation.

This means that next time a commit is merged to `dev-9.0`, we will possibly see similar breakages.

Let's pin the version to a stable one here on `dev-9.0` in advance of a sync between `tf-dev` and `dev-9.0` just in case we get similar breakage on this branch.
