### PR TITLE
MORPH-14001: fix subnet request key resourcePermission -> resourcePermissions

### DIFF
--- a/components/examples/subnetCreateRequest.json
+++ b/components/examples/subnetCreateRequest.json
@@ -23,7 +23,7 @@
     "visibility": "private",
     "labels": ["production", "azure"]
   },
-  "resourcePermission": {
+  "resourcePermissions": {
     "all": true
   }
 }

--- a/components/examples/subnetUpdate.json
+++ b/components/examples/subnetUpdate.json
@@ -8,7 +8,7 @@
       "subnetName": "Updated Subnet Name"
     }
   },
-  "resourcePermission": {
+  "resourcePermissions": {
     "all": true,
     "sites": [
       {

--- a/components/schemas/subnetCreate.yaml
+++ b/components/schemas/subnetCreate.yaml
@@ -60,7 +60,7 @@ subnet:
       description: Array of label strings, can be used for filtering.
       items:
         type: string
-resourcePermission:
+resourcePermissions:
   type: object
   properties:
     all:


### PR DESCRIPTION
## What & why

The Morpheus API reads subnet resource permissions from the **plural** `resourcePermissions` key on create/update (`NetworkService.parseResourcePermissions`). The subnet create request schema (`subnetCreate.yaml`, shared by `POST /api/subnets` and `PUT /api/subnets/{id}`) used the **singular** `resourcePermission`, so permissions were silently dropped — the Terraform provider's `resource_permission_groups_all` never took effect and always read back `false` (MORPH-14001).

## Change

- Rename the request property `resourcePermission` → `resourcePermissions` in `components/schemas/subnetCreate.yaml` and the two request examples (`subnetCreateRequest.json`, `subnetUpdate.json`).
- The GET **response** schema (`components/schemas/subnet.yaml`) intentionally keeps the singular `resourcePermission` and is unchanged (that is the key the API actually returns).

## Related PRs

- Companion Terraform provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1292

## Jira

- https://hpe.atlassian.net/browse/MORPH-14001

