### PR TITLE
MORPH-12235: Document QGA guestAgentStatus and disableQgaChannel fields

### DIFF
--- a/components/examples/server.json
+++ b/components/examples/server.json
@@ -89,6 +89,7 @@
         "agentInstalled": true,
         "lastAgentUpdate": "2022-12-19T21:45:37Z",
         "agentVersion": "2.3.2",
+        "guestAgentStatus": "unknown",
         "maxCores": 1,
         "coresPerSocket": 1,
         "maxMemory": 1073741824,

--- a/components/schemas/instancesConfigHVM.yaml
+++ b/components/schemas/instancesConfigHVM.yaml
@@ -17,6 +17,12 @@ properties:
     enum:
       - "on"
       - "off"
+  disableQgaChannel:
+    type:
+      - boolean
+      - 'null'
+    description: Exclude the virtio-serial channel for the QEMU Guest Agent from the VM. Intended for VMs that do not use a guest agent or need the slot for another device. Takes effect on existing VMs only after a full power-off.
+    default: false
   createUser:
     type:
       - boolean

--- a/components/schemas/server.yaml
+++ b/components/schemas/server.yaml
@@ -269,6 +269,17 @@ properties:
     type:
       - string
       - 'null'
+  guestAgentStatus:
+    type:
+      - string
+      - 'null'
+    enum:
+      - connected
+      - disconnected
+      - configured
+      - unconfigured
+      - unknown
+      - error
   maxCores:
     type: integer
     format: int64
@@ -557,6 +568,8 @@ properties:
         type:
           - string
           - 'null'
+      disableQgaChannel:
+        type: boolean
       vmwareFolderId:
         type: string
       noAgent:


### PR DESCRIPTION
- Add guestAgentStatus response property to server schema (existing field from PCCP-4061, was only documented as a query filter param)
- Add disableQgaChannel to the config object in the server response schema
- Add disableQgaChannel to instancesConfigHVM create-request schema, alongside sibling noAgent/nestedVirtualization options