### PR TITLE
Correct affinity group create and update schemas

### DIFF
--- a/components/schemas/clusterAffinityGroupCreate.yaml
+++ b/components/schemas/clusterAffinityGroupCreate.yaml
@@ -1,8 +1,5 @@
 type: object
 properties:
-  id:
-    type: integer
-    format: int64
   name:
     type: string
     description: Name
@@ -29,6 +26,15 @@ properties:
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml
+  tenants:
+    type: array
+    description: Array of tenant account ids that are allowed access
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
   resourcePermissions:
     type: object
     description: Resource Permissions for controlling Group Access

--- a/components/schemas/clusterAffinityGroupUpdate.yaml
+++ b/components/schemas/clusterAffinityGroupUpdate.yaml
@@ -3,22 +3,11 @@ properties:
   name:
     type: string
     description: Name
-  affinityType:
-    type: string
-    description: Affinity Type
-    enum:
-      - KEEP_TOGETHER
-      - KEEP_SEPARATE
+  # affinityType and pool are create-only. AffinityGroupService.updateAffinityGroup
+  # never assigns either, so sending them on update has no effect.
   active:
     type: boolean
     description: Active
-  pool:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-    description: Resource Pool ID to scope the Affinity Group to
   servers:
     type: array
     items:
@@ -26,6 +15,15 @@ properties:
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml
+  tenants:
+    type: array
+    description: Array of tenant account ids that are allowed access
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
   resourcePermissions:
     type: object
     description: Resource Permissions for controlling Group Access

--- a/components/schemas/zoneAffinityGroupUpdate.yaml
+++ b/components/schemas/zoneAffinityGroupUpdate.yaml
@@ -3,22 +3,11 @@ properties:
   name:
     type: string
     description: Name
-  affinityType:
-    type: string
-    description: Affinity Type
-    enum:
-      - KEEP_TOGETHER
-      - KEEP_SEPARATE
+  # affinityType and pool are create-only. AffinityGroupService.updateAffinityGroup
+  # never assigns either, so sending them on update has no effect.
   active:
     type: boolean
     description: Active
-  pool:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-    description: Resource Pool ID to scope the Affinity Group to
   servers:
     type: array
     items:


### PR DESCRIPTION
Aligns the cloud and cluster affinity group schemas with actual API behaviour. Verified against the API implementation.

## Changes

| Schema | Change |
|---|---|
| `zoneAffinityGroupUpdate` | Remove `affinityType` and `pool` |
| `clusterAffinityGroupUpdate` | Remove `affinityType` and `pool`, add `tenants` |
| `clusterAffinityGroupCreate` | Remove `id`, add `tenants` |

**`affinityType` and `pool` are create-only.** Both are accepted on update requests today but are never applied, so the schema advertises updatable fields that silently do nothing. Generated clients model them as mutable and produce misleading no-op updates.

**`id` should not be client-supplied on create.** The cloud create schema already omits it; the cluster one did not.

**`tenants` was missing from the cluster schemas.** The API accepts tenant permissions for both variants, and the cloud schemas already declare it — this brings cluster into line.

## Result

The two variants are now symmetric, and create and update are correctly distinguished:

- **Create:** `name, affinityType, active, pool, servers, visibility, tenants, resourcePermissions`
- **Update:** `name, active, servers, visibility, tenants, resourcePermissions`

## Validation

- `redocly lint` shows no new problems. The two errors reported are pre-existing in `networkRouter.yaml`; the affinity group warnings are the pre-existing `$ref`-in-example pattern found throughout the spec.
- All four committed examples remain valid against the tightened schemas — no example changes required.