### PR TITLE
MORPH-12239: Adding connect/disconnect for link status and force query parameter to the resize API for overriding storage migration with snapshots.

### DIFF
--- a/components/examples/networkInterfaceUpdate.json
+++ b/components/examples/networkInterfaceUpdate.json
@@ -1,3 +1,4 @@
 {
-    "name": "newLabelName"
+    "name": "newLabelName",
+    "connected": true
 }

--- a/components/parameters/force-resize.yaml
+++ b/components/parameters/force-resize.yaml
@@ -1,0 +1,8 @@
+name: force
+in: query
+description: Proceed with the resize, overriding the snapshot deletion restriction
+required: false
+schema:
+  type: boolean
+  default: false
+example: true

--- a/components/schemas/networkInterfaceUpdate.yaml
+++ b/components/schemas/networkInterfaceUpdate.yaml
@@ -2,5 +2,12 @@ type: object
 properties:
   name:
     type: string
-    description: Desired Name for the Network Interface
+    description: Desired Name for the Network Interface. Optional.
     example: eth0-new
+  connected:
+    type: boolean
+    description: >-
+      Optional. Controls the NIC link status. Setting to true brings the
+      network interface link status up (connected); setting to false brings
+      the link status down (disconnected).
+    example: true

--- a/paths/api@instances@id@networkInterfaces@id.yaml
+++ b/paths/api@instances@id@networkInterfaces@id.yaml
@@ -1,6 +1,9 @@
 put:
   summary: Updating a label for an Instance's Network
-  description: Updating an Instance's Network's Label
+  description: >-
+    Updating an Instance's Network's Label. Both name and connected are
+    optional parameters. The connected parameter can be used to bring the
+    NIC's link status up (true) or down (false).
   operationId: updateInstanceNetworkInterface
   tags: 
     -  Instances

--- a/paths/api@instances@id@resize.yaml
+++ b/paths/api@instances@id@resize.yaml
@@ -6,7 +6,8 @@ put:
     -  Instances
   parameters:
     - $ref: ../components/parameters/id-path.yaml
-  requestBody: 
+    - $ref: ../components/parameters/force-resize.yaml
+  requestBody:
     content: 
       application/json: 
         schema:


### PR DESCRIPTION
Stories:
https://hpe.atlassian.net/browse/MORPH-12239
https://hpe.atlassian.net/browse/MORPH-12223