### PR TITLE
Correct server interface reference types

### DIFF
--- a/components/schemas/clusterMasters.yaml
+++ b/components/schemas/clusterMasters.yaml
@@ -341,20 +341,38 @@ properties:
               type: string
         subnet:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkGroup:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkPosition:
           type:
             - string
             - 'null'
         networkPool:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkDomain:
           type:
             - object

--- a/components/schemas/clusterWorkers.yaml
+++ b/components/schemas/clusterWorkers.yaml
@@ -341,20 +341,38 @@ properties:
               type: string
         subnet:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkGroup:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkPosition:
           type:
             - string
             - 'null'
         networkPool:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkDomain:
           type:
             - object

--- a/components/schemas/guidance.yaml
+++ b/components/schemas/guidance.yaml
@@ -527,12 +527,24 @@ properties:
                   type: string
             subnet:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             networkGroup:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             networkPosition:
               type:
                 - string
@@ -547,8 +559,14 @@ properties:
                   type: string
             networkDomain:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             type:
               type: object
               properties:

--- a/components/schemas/guidanceVmwareSizing.yaml
+++ b/components/schemas/guidanceVmwareSizing.yaml
@@ -527,12 +527,24 @@ properties:
                   type: string
             subnet:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             networkGroup:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             networkPosition:
               type:
                 - string

--- a/components/schemas/networkInterfaceUpdateSuccess.yaml
+++ b/components/schemas/networkInterfaceUpdateSuccess.yaml
@@ -37,8 +37,14 @@ properties:
         type: string
       subnet:
         type:
-          - string
+          - object
           - 'null'
+        properties:
+          id:
+            type: integer
+            format: int64
+          name:
+            type: string
       replaceHostRecord:
         type: boolean
       ipMode:
@@ -77,8 +83,14 @@ properties:
           - 'null'
       networkGroup:
         type:
-          - string
+          - object
           - 'null'
+        properties:
+          id:
+            type: integer
+            format: int64
+          name:
+            type: string
       refId:
         type:
           - string
@@ -326,8 +338,14 @@ properties:
               type: string
             subnet:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             replaceHostRecord:
               type: boolean
             ipMode:
@@ -366,8 +384,14 @@ properties:
                 - 'null'
             networkGroup:
               type:
-                - string
+                - object
                 - 'null'
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
             refId:
               type:
                 - string

--- a/components/schemas/server.yaml
+++ b/components/schemas/server.yaml
@@ -444,12 +444,24 @@ properties:
               type: string
         subnet:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkGroup:
           type:
-            - string
+            - object
             - 'null'
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
         networkPosition:
           type:
             - string


### PR DESCRIPTION
The server interface fields `subnet`, `networkGroup`, `networkPool` and `networkDomain` are rendered by the API as nullable objects with `id` and `name`, but several schemas declared them as nullable strings.

## Why this matters

Generated clients type these as strings, so decoding any real response containing one fails outright — taking the whole endpoint with it, not just the offending field:

```
'servers[197].interfaces[0].subnet' expected type 'string',
got unconvertible type 'map[string]interface {}'
```

That makes the Hosts list endpoint unusable on any appliance with a subnet-assigned interface.

## Evidence

Verified against a live 9.0.2 appliance across 371 interfaces:

| Field | Observed |
|---|---|
| `subnet` | `null` ×359, object ×12 — e.g. `{"id":165336,"name":"default (10.128.0.0/20)"}`. Never a string. |
| `networkPool` | `null` ×360, object ×11 |
| `network` | object ×250, `null` ×121 — already declared correctly |

The API view renders all four as `[id: …, name: …]` or `null`. `networkPosition` is emitted unwrapped and is genuinely a scalar, so it is left alone.

Note `components/examples/instance.json` already shipped `subnet` and `networkGroup` as `{id, name}` objects — the committed examples were contradicting the schema.

## Scope

All eight server-interface contexts, found by structurally parsing every schema file rather than matching on name:

| Schema | Contexts |
|---|---|
| `server.yaml` | 1 |
| `clusterMasters.yaml` / `clusterWorkers.yaml` | 2 |
| `guidance.yaml` / `guidanceVmwareSizing.yaml` | 2 |
| `networkInterfaceUpdateSuccess.yaml` | 2 |
| `instance.yaml` | 1 (already correct) |

A completeness assertion across all 1,598 spec files confirms no string-typed occurrence of these fields remains in any server-interface context.

Deliberately out of scope: the standalone `subnet` / `networkGroup` / `networkPool` resource schemas, `networkPoolServer*`, router interfaces, provisioning `config.networkInterfaces[]`, and `instanceCreate*` `interfaces[].network.subnet` — a different nested field.

## Validation

`redocly lint` unchanged at 2 errors / 1067 warnings; both errors are pre-existing in `networkRouter.yaml`. All modified files re-parse cleanly, and all 21 concrete server-interface examples in the repo are objects or `null`, so none are invalidated.

## Related PRs

- Companion provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1332