### PR TITLE
Type affinity group server ids as int64

### DIFF
--- a/components/schemas/clusterAffinityGroupCreate.yaml
+++ b/components/schemas/clusterAffinityGroupCreate.yaml
@@ -23,6 +23,7 @@ properties:
     type: array
     items:
       type: integer
+      format: int64
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml

--- a/components/schemas/clusterAffinityGroupUpdate.yaml
+++ b/components/schemas/clusterAffinityGroupUpdate.yaml
@@ -12,6 +12,7 @@ properties:
     type: array
     items:
       type: integer
+      format: int64
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml

--- a/components/schemas/zoneAffinityGroupCreate.yaml
+++ b/components/schemas/zoneAffinityGroupCreate.yaml
@@ -23,6 +23,7 @@ properties:
     type: array
     items:
       type: integer
+      format: int64
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml

--- a/components/schemas/zoneAffinityGroupUpdate.yaml
+++ b/components/schemas/zoneAffinityGroupUpdate.yaml
@@ -12,6 +12,7 @@ properties:
     type: array
     items:
       type: integer
+      format: int64
     description: List of Server IDs to include in the Affinity Group
   visibility:
     $ref: visibility.yaml


### PR DESCRIPTION
The `servers` array on the affinity group create and update requests declares its items as a bare integer, so generated clients type them as 32-bit and must narrow the 64-bit ids the API actually uses.

## Why this matters

Static analysis flags the narrowing as an integer-overflow conversion (`gosec` G115), and it would silently cap at roughly 2.1 billion. Real ids are nowhere near that today, but the cap is latent and the type is simply wrong.

## Evidence

Compute server ids are 64-bit:

- The compute server domain object uses the ORM's default identity, which is a 64-bit `Long`. There is no narrowing anywhere in the domain layer.
- The affinity group API parses incoming ids with `.toLong()` — not `.toInteger()` — on every create and update path.
- Neighbouring id fields throughout the domain are declared `Long`.

**The spec already agreed with itself everywhere else.** In `zoneAffinityGroup.yaml` the sibling `pool.id` carries `format: int64`, and the response schemas model `servers` as objects whose `id` is `format: int64`. Only these four request schemas flattened to a bare integer.

For scale: of 154 arrays-of-integer across the spec, 138 already carry `format: int64`.

## Scope

Four one-line additions:

| Schema |
|---|
| `zoneAffinityGroupCreate` |
| `zoneAffinityGroupUpdate` |
| `clusterAffinityGroupCreate` |
| `clusterAffinityGroupUpdate` |

## Deliberately out of scope

A tree-wide sweep found 16 further arrays of object ids that omit `format: int64`, with the same quality of evidence — `securityGroupIds` on `/api/apps/{id}/security-groups` (whose sibling instances and zones endpoints already declare int64, served by the same controller), and 15 across monitoring `checks` / `checkGroups` / `groups` / `apps` (where `checkApp.yaml` and `checkGroup.yaml` already model the same logical fields as int64, and the controllers use `.toLong()`).

They are left for a separate change: correcting them alters generated models in unrelated subsystems, which does not belong in a fix scoped to affinity groups.

## Validation

`redocly lint` unchanged at 2 errors / 1067 warnings. Both errors are pre-existing and unrelated — `networkRouters.yaml:158` and `networkRouter.yaml:216`, both `Property 'config' is not expected here`. All four files re-parse, and the committed request examples carry plain integers that remain valid.

## Related PRs

- Companion provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1332