### PR TITLE
Type remaining id arrays as int64

### DIFF
--- a/components/schemas/alert.yaml
+++ b/components/schemas/alert.yaml
@@ -30,18 +30,21 @@ properties:
       - 'null'
     items:
       type: integer
+      format: int64
   checkGroups:
     type:
       - array
       - 'null'
     items:
       type: integer
+      format: int64
   apps:
     type:
       - array
       - 'null'
     items:
       type: integer
+      format: int64
   contacts:
     type: array
     items:

--- a/paths/api@apps@id@security-groups.yaml
+++ b/paths/api@apps@id@security-groups.yaml
@@ -51,6 +51,7 @@ post:
                   type: array
                   items: 
                     type: integer
+                    format: int64
         examples:
           App Update:
             value:

--- a/paths/api@monitoring@alerts.yaml
+++ b/paths/api@monitoring@alerts.yaml
@@ -86,14 +86,17 @@ post:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 groups:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 apps:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 contacts: 
                   type: array
                   items: 

--- a/paths/api@monitoring@alerts@id.yaml
+++ b/paths/api@monitoring@alerts@id.yaml
@@ -99,14 +99,17 @@ put:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 groups:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 apps:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 contacts: 
                   type: array
                   items: 

--- a/paths/api@monitoring@apps.yaml
+++ b/paths/api@monitoring@apps.yaml
@@ -83,10 +83,12 @@ post:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 checkGroups:
                   type: array
                   items:
                     type: integer
+                    format: int64
   responses:
     '200':
       description: Check App Object

--- a/paths/api@monitoring@apps@id.yaml
+++ b/paths/api@monitoring@apps@id.yaml
@@ -84,10 +84,12 @@ put:
                   type: array
                   items:
                     type: integer
+                    format: int64
                 checkGroups:
                   type: array
                   items:
                     type: integer
+                    format: int64
   responses:
     '200':
       description: Check App Object

--- a/paths/api@monitoring@groups.yaml
+++ b/paths/api@monitoring@groups.yaml
@@ -87,6 +87,7 @@ post:
                   type: array
                   items:
                     type: integer
+                    format: int64
   responses:
     '200':
       description: Check Group Object

--- a/paths/api@monitoring@groups@id.yaml
+++ b/paths/api@monitoring@groups@id.yaml
@@ -80,6 +80,7 @@ put:
                   type: array
                   items:
                     type: integer
+                    format: int64
   responses:
     '200':
       description: Check Group Object


### PR DESCRIPTION
Follow-up to #319, which corrected the affinity group `servers` arrays. A tree-wide sweep found sixteen further arrays of object ids still declaring bare integers; this brings them into line.

## Why this matters

An array of object ids without `format: int64` causes generated clients to type it as 32-bit, forcing a narrowing of the 64-bit ids the API actually uses. Static analysis flags it as an integer-overflow conversion, and it silently caps at roughly 2.1 billion. In the affinity group case this surfaced as four `gosec` G115 failures in a downstream provider build.

## The spec already disagreed with itself

Both clusters are internal contradictions rather than judgement calls.

**Security groups.** `/api/apps/{id}/security-groups`, `/api/instances/{id}/security-groups` and `/api/zones/{id}/security-groups` are routed to the *same* controller, which reads a single `securityGroupIds` payload and rejects it with "Array of IDs is required". The instances and zones schemas already declared `format: int64`; only the apps one did not.

**Monitoring.** `checkApp.yaml` and `checkGroup.yaml` already model `checks` and `checkGroups` as `int64`. The same logical fields were modelled both ways. The monitoring controllers parse these ids with `.toLong()` — the only `.toInteger()` calls are pagination parameters (`max`, `offset`, `hours`), never entity ids. These fields also sit directly beside `allChecks` / `allGroups` / `allApps` booleans, the familiar "all, or this specific id list" pattern.

## Scope

Sixteen insertions across eight files, no deletions:

| File | Fields |
|---|---|
| `components/schemas/alert.yaml` | `checks`, `checkGroups`, `apps` |
| `paths/api@apps@id@security-groups.yaml` | `securityGroupIds` |
| `paths/api@monitoring@alerts.yaml` + `@id` | `checks`, `groups`, `apps` |
| `paths/api@monitoring@apps.yaml` + `@id` | `checks`, `checkGroups` |
| `paths/api@monitoring@groups.yaml` + `@id` | `checks` |

**Before:** 154 arrays of integers, 138 with `int64`, 16 without.
**After:** 154 of 154.

Deliberately untouched: the same-named arrays in the GET *response* schemas of those files. Those are `$ref` arrays of full objects rather than ids — `components/examples/alert.json` shows the split exactly, with `alert.checks` as `[3, 1945]` while the envelope's `checks` is an array of objects.

## Method

The sweep parsed the node graph of all 1,602 YAML files rather than matching text, since key ordering varies and `type: [array, 'null']` unions defeat a textual match. Arrays whose `items` is a `$ref` (268), uses `oneOf`/`anyOf`/`allOf` (7), or omits `type` (12) were resolved and checked too — none resolve to an integer schema, confirming sixteen was the true total.

## Validation

`redocly lint` output is byte-identical before and after apart from timing: 2 errors / 1067 warnings. Both errors are pre-existing and unrelated — `networkRouters.yaml:158` and `networkRouter.yaml:216`, both `Property 'config' is not expected here`. `redocly bundle` resolves cleanly.

Every example bound to a modified schema uses plain integers well inside int64 range, so none are invalidated.