### PR TITLE
MORPH-12245: Document bootToBios and bootToBiosMenuTimeout fields for HVM instances

### DIFF
--- a/components/examples/server.json
+++ b/components/examples/server.json
@@ -232,7 +232,9 @@
             "nestedVirtualization": null,
             "vmwareFolderId": "group-v80",
             "noAgent": false,
-            "powerScheduleType": null
+            "powerScheduleType": null,
+            "bootToBios": true,
+            "bootToBiosMenuTimeout": 0
         },
         "instance": {
             "id": 2342422,

--- a/components/examples/servers.json
+++ b/components/examples/servers.json
@@ -213,7 +213,11 @@
       "guestConsoleUsername": null,
       "guestConsolePassword": null,
       "guestConsolePasswordHash": null,
-      "guestConsolePort": null
+      "guestConsolePort": null,
+      "config": {
+        "bootToBios": true,
+        "bootToBiosMenuTimeout": 0
+      }
     }
   ],
   "stats": {

--- a/components/schemas/instancesConfigHVM.yaml
+++ b/components/schemas/instancesConfigHVM.yaml
@@ -41,3 +41,17 @@ properties:
     type: boolean
     description: Whether to provision the instance in a powered off state
     default: false
+  bootToBios:
+    type:
+      - boolean
+      - 'null'
+    description: Enable or disable the QEMU boot menu at VM startup. When enabled, the VM displays a boot selection menu. Defaults to true for new HVM VMs.
+    default: true
+  bootToBiosMenuTimeout:
+    type:
+      - integer
+      - 'null'
+    description: Boot menu display duration in seconds (0-30). Only applicable when bootToBios is true. A value of 0 means no delay.
+    default: 0
+    minimum: 0
+    maximum: 30

--- a/components/schemas/server.yaml
+++ b/components/schemas/server.yaml
@@ -570,6 +570,14 @@ properties:
           - 'null'
       disableQgaChannel:
         type: boolean
+      bootToBios:
+        type:
+          - boolean
+          - 'null'
+      bootToBiosMenuTimeout:
+        type:
+          - integer
+          - 'null'
       vmwareFolderId:
         type: string
       noAgent:


### PR DESCRIPTION
- Add bootToBios to instancesConfigHVM create-request schema — enables/disables the QEMU boot menu at VM startup, defaults to true for new HVM VMs
- Add bootToBiosMenuTimeout to instancesConfigHVM create-request schema — boot menu display duration in seconds (0–30), default 0
- Add both fields to the config object in the server response schema