### PR TITLE
Add affinity group selection to the instance config schemas (MORPH-15596)

### DIFF
--- a/components/schemas/instancesConfigHVM.yaml
+++ b/components/schemas/instancesConfigHVM.yaml
@@ -31,6 +31,23 @@ properties:
     type: integer
     format: int64
     description: The ID of the KVM host to provision the instance on
+  affinityGroup:
+    type: integer
+    format: int64
+    description: >-
+      ID of an affinity group to add this instance's servers to. This records
+      membership; it does not by itself influence which host the instance is
+      placed on. Placement is applied by the cluster's dynamic placement loop,
+      which must be enabled on the cluster. Applies at provision time only.
+  affinityGroupId:
+    type: integer
+    format: int64
+    description: >-
+      ID of an affinity group to consider during host selection. For a
+      KEEP_TOGETHER group the instance is placed on the same host as the group's
+      existing members. Has no effect for a KEEP_SEPARATE group, or when the
+      group has no members yet. Normally set to the same value as affinityGroup,
+      which records the membership itself. Applies at provision time only.
   provisionPoweredOff:
     type: boolean
     description: Whether to provision the instance in a powered off state

--- a/components/schemas/instancesConfigVMWare.yaml
+++ b/components/schemas/instancesConfigVMWare.yaml
@@ -13,6 +13,14 @@ properties:
   hostId:
     type: string
     description: Specific host to deploy to if so desired.
+  affinityGroup:
+    type: integer
+    format: int64
+    description: >-
+      ID of an affinity group to place this instance into. The placement rule is
+      applied to the cluster before the virtual machine is powered on, so the
+      instance is placed according to the rule from the outset. Applies at
+      provision time only.
   smbiosAssetTag:
     type: string
     description: Sets the asset tag on the SMBIOS for use by the guest operating system. If left blank, the virtual machine name will be used.


### PR DESCRIPTION
## Summary

Documents the affinity group fields accepted by the instance provisioning config
for VMware and HVM, so an instance can be placed into an affinity group at
provision time.

`instancesConfigVMWare` gains `affinityGroup`. `instancesConfigHVM` gains both
`affinityGroup` and `affinityGroupId`, which are separate inputs on that path:
one records membership, the other participates in host selection. They are
normally set to the same value.

## Behaviour captured in the descriptions

Verified against a 9.0.2 appliance with real VMware and HVM infrastructure:

- On VMware the rule reaches the cluster before the virtual machine powers on,
  so the instance is placed according to it from the outset. The group must
  already have a member: a DRS rule requires two virtual machines, so the first
  machine into an empty group produces a rule vCenter rejects, and provisioning
  fails at power on.
- On HVM `affinityGroupId` reliably affects host selection only for a
  `KEEP_TOGETHER` group that already has members. A `KEEP_SEPARATE` violation is
  resolved afterwards by the cluster's dynamic placement loop, which live-migrates
  the instance two to six minutes later, and only when that loop is enabled on
  the cluster.

## Related PRs

- Companion provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1335

Merge order: the provider PR merges first. Its SDK is generated and vendored
in-tree, so it is self-contained; this PR records the spec it was generated
from.

MORPH-15596
