### PR TITLE
Return the affinity group fields when reading an instance (MORPH-15596)

### DIFF
--- a/components/schemas/instance.yaml
+++ b/components/schemas/instance.yaml
@@ -156,6 +156,26 @@ properties:
           - integer
           - 'null'
         format: int64
+      affinityGroup:
+        type:
+          - integer
+          - 'null'
+        format: int64
+        description: >-
+          ID of the affinity group this instance's servers were added to when it
+          was provisioned. Recorded at provision time and not updated
+          afterwards, so it reflects what was requested rather than current
+          membership. Current membership is reported by the affinity group
+          itself.
+      affinityGroupId:
+        type:
+          - integer
+          - 'null'
+        format: int64
+        description: >-
+          ID of the affinity group considered during host selection when the
+          instance was provisioned. Recorded at provision time and not updated
+          afterwards. Normally the same value as affinityGroup.
       cloneInstanceId:
         type:
           - integer


### PR DESCRIPTION
## Summary

Declares `affinityGroup` and `affinityGroupId` on the instance `config` read
schema. The response already carries both — they were simply undeclared, so a
generated client had no way to recover them.

Follow-up to #324, which added the same fields to the create schemas. That PR
covered the request side only; this covers the response.

## Why it matters

Without these on the read schema, a client cannot tell which affinity group an
existing instance was provisioned into. In the Terraform provider this surfaced
as a broken import: importing an instance that had been placed into an affinity
group produced a plan proposing to destroy and recreate it, because the
attribute forces replacement and came back empty.

Verified against a 9.0.2.94 appliance — `GET /api/instances/{id}` returns both
fields populated:

```json
"config": { "affinityGroup": 6245, "affinityGroupId": 6245 }
```

## Note on semantics

Both fields are recorded at provision time and are not updated afterwards, so
they reflect what was requested rather than current membership. The descriptions
say so explicitly, and point readers at the affinity group itself for live
membership. That distinction matters: the value is a safe basis for import, but
not a source of truth for where an instance currently sits.

MORPH-15596
