### PR TITLE
Document the group-{id} format required for firewall rule parentId

### DIFF
--- a/components/schemas/networkRouterFirewallRuleCreate.yaml
+++ b/components/schemas/networkRouterFirewallRuleCreate.yaml
@@ -44,4 +44,8 @@ properties:
     properties:
       parentId:
         type: string
-        description: External id of the parent firewall rule group (required by NSX-T).
+        description: >-
+          External id of the parent firewall rule group (required by NSX-T).
+          Must be in the format "group-{id}", where {id} is the id of the
+          firewall rule group - for example "group-123". Any other format is
+          rejected.


### PR DESCRIPTION
## What

Documents the format required by `config.parentId` on
`networkRouterFirewallRuleCreate`.

## Why

The API only accepts this value as `group-{id}` — it checks that the value
starts with `group-` and that the remainder is a numeric firewall rule group id.
The previous description ("External id of the parent firewall rule group
(required by NSX-T)") did not say so, which made it easy to pass a bare numeric
id and get an unhelpful failure.

## Details

Description-only change; no structural or type changes, so it is
backwards-compatible for generated clients. The schema is referenced by both
`POST` and `PUT` on `/api/networks/routers/{id}/firewall-rules`, so the
clarification covers create and update.

```yaml
parentId:
  type: string
  description: >-
    External id of the parent firewall rule group (required by NSX-T).
    Must be in the format "group-{id}", where {id} is the id of the
    firewall rule group - for example "group-123". Any other format is
    rejected.
```

No `pattern` keyword was added: the spec does not currently use `pattern`
anywhere, so this stays consistent with the surrounding style.


## Related PRs

- Companion provider PR: https://github.com/HPE/terraform-provider-hpe/pull/1339
