### PR TITLE
Align clients OpenAPI with ClientsController

### DIFF
--- a/components/examples/client.json
+++ b/components/examples/client.json
@@ -1,24 +1,24 @@
 {
-  "client": {
-    "id": 2,
-    "clientId": "morph-cli",
-    "clientSecret": "************",
-    "clientSecretHash": "a1b2c3d4e5f67890",
-    "accessTokenValiditySeconds": 31536000,
-    "refreshTokenValiditySeconds": 31536000,
-    "authorizedGrantTypes": [
-      "authorization_code",
-      "refresh_token",
-      "password"
-    ],
-    "scopes": [
-      "write",
-      "openid"
-    ],
-    "redirectUris": [
-      "https://example.com/callback"
-    ],
-    "requireConsent": false,
-    "system": false
-  }
+    "client": {
+        "id": 2,
+        "clientId": "morph-cli",
+        "clientSecret": "************",
+        "clientSecretHash": "a1b2c3d4e5f67890",
+        "accessTokenValiditySeconds": 31536000,
+        "refreshTokenValiditySeconds": 31536000,
+        "authorizedGrantTypes": [
+            "authorization_code",
+            "refresh_token",
+            "password"
+        ],
+        "scopes": [
+            "write",
+            "openid"
+        ],
+        "redirectUris": [
+            "https://example.com/callback"
+        ],
+        "requireConsent": false,
+        "system": false
+    }
 }

--- a/components/examples/client.json
+++ b/components/examples/client.json
@@ -1,25 +1,24 @@
 {
-    "client": {
-        "id": 2,
-        "clientId": "morph-cli",
-        "accessTokenValiditySeconds": 31536000,
-        "refreshTokenValiditySeconds": 31536000,
-        "authorities": [
-            "ROLE_CLIENT"
-        ],
-        "authorizedGrantTypes": [
-            "refresh_token",
-            "implicit",
-            "password",
-            "client_credentials",
-            "authorization_code"
-        ],
-        "scopes": [
-            "read",
-            "write"
-        ],
-        "redirectUris": [
-            
-        ]
-    }
+  "client": {
+    "id": 2,
+    "clientId": "morph-cli",
+    "clientSecret": "************",
+    "clientSecretHash": "a1b2c3d4e5f67890",
+    "accessTokenValiditySeconds": 31536000,
+    "refreshTokenValiditySeconds": 31536000,
+    "authorizedGrantTypes": [
+      "authorization_code",
+      "refresh_token",
+      "password"
+    ],
+    "scopes": [
+      "write",
+      "openid"
+    ],
+    "redirectUris": [
+      "https://example.com/callback"
+    ],
+    "requireConsent": false,
+    "system": false
+  }
 }

--- a/components/examples/clientSuccess.json
+++ b/components/examples/clientSuccess.json
@@ -1,25 +1,25 @@
 {
-  "success": true,
-  "client": {
-    "id": 29,
-    "clientId": "morph-api-client-here",
-    "clientSecret": "************",
-    "clientSecretHash": "a1b2c3d4e5f67890",
-    "accessTokenValiditySeconds": 43200,
-    "refreshTokenValiditySeconds": 43200,
-    "authorizedGrantTypes": [
-      "authorization_code",
-      "refresh_token",
-      "password"
-    ],
-    "scopes": [
-      "write",
-      "openid"
-    ],
-    "redirectUris": [
-      "https://example.com/callback"
-    ],
-    "requireConsent": false,
-    "system": false
-  }
+    "success": true,
+    "client": {
+        "id": 29,
+        "clientId": "morph-api-client-here",
+        "clientSecret": "************",
+        "clientSecretHash": "a1b2c3d4e5f67890",
+        "accessTokenValiditySeconds": 43200,
+        "refreshTokenValiditySeconds": 43200,
+        "authorizedGrantTypes": [
+            "authorization_code",
+            "refresh_token",
+            "password"
+        ],
+        "scopes": [
+            "write",
+            "openid"
+        ],
+        "redirectUris": [
+            "https://example.com/callback"
+        ],
+        "requireConsent": false,
+        "system": false
+    }
 }

--- a/components/examples/clientSuccess.json
+++ b/components/examples/clientSuccess.json
@@ -1,24 +1,25 @@
 {
-    "success": true,
-    "client": {
-        "id": 29,
-        "clientId": "morph-api-client-here",
-        "accessTokenValiditySeconds": 49,
-        "refreshTokenValiditySeconds": 55,
-        "authorities": [
-            "ROLE_CLIENT"
-        ],
-        "authorizedGrantTypes": [
-            "refresh_token",
-            "implicit",
-            "password",
-            "client_credentials",
-            "authorization_code"
-        ],
-        "scopes": [
-            "read",
-            "write"
-        ],
-        "redirectUris": []
-    }
+  "success": true,
+  "client": {
+    "id": 29,
+    "clientId": "morph-api-client-here",
+    "clientSecret": "************",
+    "clientSecretHash": "a1b2c3d4e5f67890",
+    "accessTokenValiditySeconds": 43200,
+    "refreshTokenValiditySeconds": 43200,
+    "authorizedGrantTypes": [
+      "authorization_code",
+      "refresh_token",
+      "password"
+    ],
+    "scopes": [
+      "write",
+      "openid"
+    ],
+    "redirectUris": [
+      "https://example.com/callback"
+    ],
+    "requireConsent": false,
+    "system": false
+  }
 }

--- a/components/examples/clients.json
+++ b/components/examples/clients.json
@@ -1,68 +1,68 @@
 {
-  "clients": [
-    {
-      "id": 3,
-      "clientId": "morph-api",
-      "accessTokenValiditySeconds": 31536000,
-      "refreshTokenValiditySeconds": 31536000,
-      "authorizedGrantTypes": [
-        "authorization_code",
-        "refresh_token",
-        "password"
-      ],
-      "scopes": [
-        "write",
-        "openid"
-      ],
-      "redirectUris": [],
-      "requireConsent": false,
-      "system": true
-    },
-    {
-      "id": 4,
-      "clientId": "morph-automation",
-      "accessTokenValiditySeconds": 1440,
-      "refreshTokenValiditySeconds": 1440,
-      "authorizedGrantTypes": [
-        "authorization_code",
-        "refresh_token",
-        "password"
-      ],
-      "scopes": [
-        "write",
-        "openid"
-      ],
-      "redirectUris": [],
-      "requireConsent": false,
-      "system": false
-    },
-    {
-      "id": 2,
-      "clientId": "morph-cli",
-      "clientSecret": "************",
-      "clientSecretHash": "a1b2c3d4e5f67890",
-      "accessTokenValiditySeconds": 31536000,
-      "refreshTokenValiditySeconds": 31536000,
-      "authorizedGrantTypes": [
-        "authorization_code",
-        "refresh_token",
-        "password"
-      ],
-      "scopes": [
-        "write",
-        "openid"
-      ],
-      "redirectUris": [
-        "https://example.com/callback"
-      ],
-      "requireConsent": false,
-      "system": false
+    "clients": [
+        {
+            "id": 3,
+            "clientId": "morph-api",
+            "accessTokenValiditySeconds": 31536000,
+            "refreshTokenValiditySeconds": 31536000,
+            "authorizedGrantTypes": [
+                "authorization_code",
+                "refresh_token",
+                "password"
+            ],
+            "scopes": [
+                "write",
+                "openid"
+            ],
+            "redirectUris": [],
+            "requireConsent": false,
+            "system": true
+        },
+        {
+            "id": 4,
+            "clientId": "morph-automation",
+            "accessTokenValiditySeconds": 1440,
+            "refreshTokenValiditySeconds": 1440,
+            "authorizedGrantTypes": [
+                "authorization_code",
+                "refresh_token",
+                "password"
+            ],
+            "scopes": [
+                "write",
+                "openid"
+            ],
+            "redirectUris": [],
+            "requireConsent": false,
+            "system": false
+        },
+        {
+            "id": 2,
+            "clientId": "morph-cli",
+            "clientSecret": "************",
+            "clientSecretHash": "a1b2c3d4e5f67890",
+            "accessTokenValiditySeconds": 31536000,
+            "refreshTokenValiditySeconds": 31536000,
+            "authorizedGrantTypes": [
+                "authorization_code",
+                "refresh_token",
+                "password"
+            ],
+            "scopes": [
+                "write",
+                "openid"
+            ],
+            "redirectUris": [
+                "https://example.com/callback"
+            ],
+            "requireConsent": false,
+            "system": false
+        }
+    ],
+    "meta": {
+        "offset": 0,
+        "max": 25,
+        "size": 3,
+        "total": 3
     }
-  ],
-  "meta": {
-    "offset": 0,
-    "max": 25,
-    "size": 3,
-    "total": 3
-  }
 }

--- a/components/examples/clients.json
+++ b/components/examples/clients.json
@@ -1,104 +1,68 @@
 {
-    "clients": [
-        {
-            "id": 3,
-            "clientId": "morph-api",
-            "accessTokenValiditySeconds": 31536000,
-            "refreshTokenValiditySeconds": 31536000,
-            "authorities": [
-                "ROLE_CLIENT"
-            ],
-            "authorizedGrantTypes": [
-                "refresh_token",
-                "implicit",
-                "password",
-                "client_credentials",
-                "authorization_code"
-            ],
-            "scopes": [
-                "read",
-                "write"
-            ],
-            "redirectUris": []
-        },
-        {
-            "id": 4,
-            "clientId": "morph-automation",
-            "accessTokenValiditySeconds": 1440,
-            "refreshTokenValiditySeconds": 1440,
-            "authorities": [
-                "ROLE_CLIENT"
-            ],
-            "authorizedGrantTypes": [
-                "refresh_token",
-                "implicit",
-                "password",
-                "client_credentials",
-                "authorization_code"
-            ],
-            "scopes": [
-                "read",
-                "write"
-            ],
-            "redirectUris": []
-        },
-        {
-            "id": 2,
-            "clientId": "morph-cli",
-            "accessTokenValiditySeconds": 31536000,
-            "refreshTokenValiditySeconds": 31536000,
-            "authorities": [
-                "ROLE_CLIENT"
-            ],
-            "authorizedGrantTypes": [
-                "refresh_token",
-                "implicit",
-                "password",
-                "client_credentials",
-                "authorization_code"
-            ],
-            "scopes": [
-                "read",
-                "write"
-            ],
-            "redirectUris": []
-        },
-        {
-            "id": 1,
-            "clientId": "morph-customer",
-            "accessTokenValiditySeconds": 31536000,
-            "refreshTokenValiditySeconds": 31536000,
-            "authorities": [
-                "ROLE_CLIENT"
-            ],
-            "authorizedGrantTypes": [
-                "refresh_token",
-                "implicit",
-                "password",
-                "client_credentials",
-                "authorization_code"
-            ],
-            "scopes": [
-                "read",
-                "write"
-            ],
-            "redirectUris": []
-        },
-        {
-            "id": 5,
-            "clientId": "morpheus-terraform",
-            "accessTokenValiditySeconds": 1440,
-            "refreshTokenValiditySeconds": 1440,
-            "authorities": [],
-            "authorizedGrantTypes": [],
-            "scopes": [],
-            "redirectUris": []
-        }
-    ],
-    "meta": {
-        "offset": 0,
-        "max": 25,
-        "size": 5,
-        "total": 5
+  "clients": [
+    {
+      "id": 3,
+      "clientId": "morph-api",
+      "accessTokenValiditySeconds": 31536000,
+      "refreshTokenValiditySeconds": 31536000,
+      "authorizedGrantTypes": [
+        "authorization_code",
+        "refresh_token",
+        "password"
+      ],
+      "scopes": [
+        "write",
+        "openid"
+      ],
+      "redirectUris": [],
+      "requireConsent": false,
+      "system": true
+    },
+    {
+      "id": 4,
+      "clientId": "morph-automation",
+      "accessTokenValiditySeconds": 1440,
+      "refreshTokenValiditySeconds": 1440,
+      "authorizedGrantTypes": [
+        "authorization_code",
+        "refresh_token",
+        "password"
+      ],
+      "scopes": [
+        "write",
+        "openid"
+      ],
+      "redirectUris": [],
+      "requireConsent": false,
+      "system": false
+    },
+    {
+      "id": 2,
+      "clientId": "morph-cli",
+      "clientSecret": "************",
+      "clientSecretHash": "a1b2c3d4e5f67890",
+      "accessTokenValiditySeconds": 31536000,
+      "refreshTokenValiditySeconds": 31536000,
+      "authorizedGrantTypes": [
+        "authorization_code",
+        "refresh_token",
+        "password"
+      ],
+      "scopes": [
+        "write",
+        "openid"
+      ],
+      "redirectUris": [
+        "https://example.com/callback"
+      ],
+      "requireConsent": false,
+      "system": false
     }
+  ],
+  "meta": {
+    "offset": 0,
+    "max": 25,
+    "size": 3,
+    "total": 3
+  }
 }

--- a/components/schemas/client.yaml
+++ b/components/schemas/client.yaml
@@ -1,29 +1,78 @@
 type: object
-properties: 
-  id: 
-    type: integer
-    format: int64
-  clientId: 
+description: OAuth client as returned by ClientsController gson (`_client.gson`).
+properties:
+  id:
+    type:
+      - integer
+      - string
+    description: Client database id
+    example: 2
+  clientId:
     type: string
-  accessTokenValiditySeconds: 
-    type: integer
-    format: int64
-  refreshTokenValiditySeconds: 
-    type: integer
-    format: int64
-  authorities: 
+    description: OAuth client identifier
+    example: morph-cli
+  clientSecret:
+    type:
+      - string
+      - 'null'
+    description: |
+      Masked client secret when a secret is set. Omitted when no secret is configured.
+      Masking uses the standard secret mask (not the raw secret value).
+    example: '************'
+  clientSecretHash:
+    type:
+      - string
+      - 'null'
+    description: |
+      Hash of the client secret when a secret is set. Omitted when no secret is configured.
+    example: a1b2c3d4e5f6
+  accessTokenValiditySeconds:
+    type:
+      - integer
+      - 'null'
+    description: Access token lifetime in seconds
+    example: 43200
+  refreshTokenValiditySeconds:
+    type:
+      - integer
+      - 'null'
+    description: Refresh token lifetime in seconds
+    example: 43200
+  authorizedGrantTypes:
     type: array
-    items: 
+    description: |
+      Grant types configured on the client. Set by the server on create
+      (defaults include authorization_code, refresh_token, password). Not writable via create/update payload.
+    items:
       type: string
-  authorizedGrantTypes: 
+    example:
+      - authorization_code
+      - refresh_token
+      - password
+  scopes:
     type: array
-    items: 
+    description: |
+      OAuth scopes on the client. Set by the server on create (defaults include write, openid).
+      Not writable via create/update payload.
+    items:
       type: string
-  scopes: 
+    example:
+      - write
+      - openid
+  redirectUris:
     type: array
-    items: 
+    description: Redirect URIs for the authorization code flow
+    items:
       type: string
-  redirectUris: 
-    type: array
-    items: 
-      type: string
+    example:
+      - https://example.com/callback
+  requireConsent:
+    type: boolean
+    description: Whether the client requires user consent
+    example: false
+  system:
+    type: boolean
+    description: |
+      True when the client is a system client (`removable != true`).
+      System clients cannot be deleted and have restricted editable fields in the UI.
+    example: false

--- a/components/schemas/clientUpdate.yaml
+++ b/components/schemas/clientUpdate.yaml
@@ -1,15 +1,50 @@
 type: object
-properties: 
-  clientId: 
+description: |
+  Writable client fields for create/update under the required `client` object.
+  Create binds: clientId, clientSecret, accessTokenValiditySeconds, refreshTokenValiditySeconds,
+  requireConsent, redirectUris.
+  Update binds the same fields when the client is removable; system clients only accept
+  accessTokenValiditySeconds and refreshTokenValiditySeconds.
+  Pass a masked secret value starting with `********` on update to leave the existing secret unchanged.
+properties:
+  clientId:
     type: string
-  accessTokenValiditySeconds: 
-    type: integer
-    format: int64
-  refreshTokenValiditySeconds: 
-    type: integer
-    format: int64
+    description: OAuth client identifier (required on create)
+    example: Test Client
+  clientSecret:
+    type:
+      - string
+      - 'null'
+    description: |
+      Client secret. On update, values starting with `********` are ignored so the existing
+      secret is retained.
+    example: thisIsaClientSecretKeyPhrase
+  accessTokenValiditySeconds:
+    type:
+      - integer
+      - string
+      - 'null'
+    description: Access token lifetime in seconds (must be a number greater than 0 when provided)
+    example: 43200
+  refreshTokenValiditySeconds:
+    type:
+      - integer
+      - string
+      - 'null'
+    description: Refresh token lifetime in seconds (must be a number greater than 0 when provided)
+    example: 43200
   redirectUris:
-    type: array
-    description: List of Redirect URIs for use with the OpenID Authorization Code Flow
-    items: 
-      type: string
+    description: |
+      Redirect URIs. Accepts a JSON array of strings or a comma-separated string.
+    oneOf:
+      - type: array
+        items:
+          type: string
+        example:
+          - https://example.com/callback
+      - type: string
+        example: https://example.com/callback, https://example.com/other
+  requireConsent:
+    type: boolean
+    description: Whether the client requires user consent
+    example: false

--- a/paths/api@clients.yaml
+++ b/paths/api@clients.yaml
@@ -1,6 +1,15 @@
 get:
-  summary: Get All Oauth Clients
-  description: This endpoint retrieves a paginated list of oauth clients.
+  summary: List OAuth clients
+  description: |
+    Returns a paginated list of OAuth clients.
+
+    List filters are applied by `ClientService.loadClientList`:
+    - `phrase` — case-insensitive partial match on `clientId`
+    - `clientId` — exact match on `clientId` (also copied into `phrase` for partial match when used as a search term)
+    - `system` — when present, filters system vs removable clients (`true`/empty string → system only)
+
+    Default page size is 25. Default sort is `clientId` ascending.
+    Response includes `clients`, `meta`, and may include `viewConfig` from the caller's data view preferences.
   operationId: listClients
   tags:
     - Clients
@@ -9,21 +18,31 @@ get:
     - $ref: ../components/parameters/offset.yaml
     - name: sort
       in: query
-      description: Sort order, the name of the property to sort by
+      description: Property name to sort by
       schema:
         type: string
         default: clientId
     - $ref: ../components/parameters/direction.yaml
     - name: phrase
       in: query
-      description: Search phrase for partial matches on clientId
+      description: Case-insensitive partial match on clientId
       schema:
         type: string
     - name: clientId
       in: query
-      description: Search phrase for partial matches on clientId
+      description: |
+        Exact match on clientId. When provided, the service also sets phrase from this value
+        for partial matching behavior used by some clients.
       schema:
         type: string
+    - name: system
+      in: query
+      description: |
+        Filter by system client flag. When the parameter is present, `true` or empty string
+        selects system clients (`removable == false`); other values select removable clients.
+      schema:
+        type: string
+        example: 'true'
   responses:
     '200':
       description: Successful Request
@@ -37,6 +56,13 @@ get:
                     type: array
                     items:
                       $ref: ../components/schemas/client.yaml
+                  viewConfig:
+                    type: object
+                    description: Optional caller data-view configuration for the clients list
+                    additionalProperties: true
+                  count:
+                    type: integer
+                    description: Optional total count when included by the list renderer
               - $ref: ../components/schemas/meta.yaml
           examples:
             Clients Response:
@@ -47,12 +73,23 @@ get:
     '5XX':
       $ref: ../components/responses/5xx.yaml
 post:
-  summary: Create an Oauth Client
-  description: Create a new Oauth Client.
+  summary: Create an OAuth client
+  description: |
+    Creates a new OAuth client.
+
+    Request body must include a `client` object. Writable fields:
+    `clientId` (required), `clientSecret`, `accessTokenValiditySeconds`,
+    `refreshTokenValiditySeconds`, `redirectUris`, `requireConsent`.
+
+    On create the server sets default `authorizedGrantTypes`, `authorities`, and `scopes`.
+    Those fields are not accepted on the create payload; they appear on the response client object
+    only where the gson template emits them (`authorizedGrantTypes` and `scopes` are returned;
+    `authorities` is not returned by the API response template).
   operationId: addClient
   tags:
     - Clients
   requestBody:
+    required: true
     content:
       application/json:
         schema:
@@ -61,38 +98,22 @@ post:
             - client
           properties:
             client:
-              type: object
-              description: Payload for creating a new oauth client
-              required:
-                - clientId
-                - accessTokenValiditySeconds
-                - refreshTokenValiditySeconds
-              properties:
-                clientId:
-                  type: string
-                  description: Client ID
-                  example: Test Client
-                clientSecret:
-                  type: string
-                  description: Client Secret
-                  example: thisIsaClientSecretKeyPhrase
-                accessTokenValiditySeconds:
-                  type:
-                    - integer
-                    - 'null'
-                  description: Length of time accessToken is valid in seconds.
-                  example: 43200
-                refreshTokenValiditySeconds:
-                  type:
-                    - integer
-                    - 'null'
-                  description: Length of time refreshToken is valid in seconds.
-                  example: 43200
+              allOf:
+                - $ref: ../components/schemas/clientUpdate.yaml
+                - type: object
+                  required:
+                    - clientId
+        examples:
+          Create Client:
+            value:
+              client:
+                clientId: Test Client
+                clientSecret: thisIsaClientSecretKeyPhrase
+                accessTokenValiditySeconds: 43200
+                refreshTokenValiditySeconds: 43200
                 redirectUris:
-                  type: array
-                  description: List of Redirect URIs for use with the OpenID Authorization Code Flow
-                  items:
-                    type: string
+                  - https://example.com/callback
+                requireConsent: false
   responses:
     '200':
       description: Client Object

--- a/paths/api@clients@id.yaml
+++ b/paths/api@clients@id.yaml
@@ -1,7 +1,7 @@
 get:
-  summary: Retrieves a Specific Oauth Client
+  summary: Get an OAuth client
   description: |
-    Retrieves a specific oauth client.
+    Retrieves a specific OAuth client by id.
   operationId: getClients
   tags:
     - Clients
@@ -27,15 +27,22 @@ get:
     '5XX':
       $ref: ../components/responses/5xx.yaml
 put:
-  summary: Updates an Oauth Client
+  summary: Update an OAuth client
   description: |
-    Updates an oauth client.
+    Updates an OAuth client.
+
+    Request body must include a `client` object. For removable clients, writable fields are
+    `clientId`, `clientSecret`, `accessTokenValiditySeconds`, `refreshTokenValiditySeconds`,
+    `redirectUris`, and `requireConsent`. System clients only accept token validity fields.
+
+    On update, a `clientSecret` value starting with `********` leaves the existing secret unchanged.
   operationId: updateClients
   tags:
     - Clients
   parameters:
     - $ref: ../components/parameters/id-path.yaml
   requestBody:
+    required: true
     content:
       application/json:
         schema:
@@ -45,6 +52,17 @@ put:
           properties:
             client:
               $ref: ../components/schemas/clientUpdate.yaml
+        examples:
+          Update Client:
+            value:
+              client:
+                clientId: Test Client
+                clientSecret: '************'
+                accessTokenValiditySeconds: 43200
+                refreshTokenValiditySeconds: 43200
+                redirectUris:
+                  - https://example.com/callback
+                requireConsent: true
   responses:
     '200':
       description: Successful Request
@@ -66,9 +84,9 @@ put:
     '5XX':
       $ref: ../components/responses/5xx.yaml
 delete:
-  summary: Deletes an Oauth Client
+  summary: Delete an OAuth client
   description: |
-    Deletes a specified oauth client.
+    Deletes a specified OAuth client. System clients cannot be deleted.
   operationId: removeClients
   tags:
     - Clients


### PR DESCRIPTION
## Summary
Align the Clients OpenAPI section with `ClientsController` / `ClientService` and `_client.gson`.

## Why
Docs lagged the live API: response omitted masked secret, secret hash, `requireConsent`, and `system`; still documented `authorities` which gson does not return. Create/update payloads were incomplete vs service bind lists. List filters missed `system`.

## What
- Response schema matches `_client.gson` (masked `clientSecret`, `clientSecretHash`, `requireConsent`, `system`; drop `authorities`)
- Create/update document writable fields including `clientSecret` and `requireConsent`; `redirectUris` as array or comma-separated string; token validity as number-like values
- List documents `phrase`, `clientId`, and `system`; notes default pagination/sort and optional `viewConfig`/`count`
- Examples updated to the current response shape
